### PR TITLE
更新処理が走っても、ずっとキャッシュを維持し続けてしまう不具合を修正

### DIFF
--- a/NyanNyanEngine/model/net/ApiClient.swift
+++ b/NyanNyanEngine/model/net/ApiClient.swift
@@ -24,11 +24,24 @@ class ApiClient: BaseApiClient {
     }
     
     private func getRequest(url: String) -> Observable<DataResponse<String>> {
+        guard let urlRequest = self.createGetUrlRequest(url: url) else { return Observable<DataResponse<String>>.empty() }
+        
         return Observable<DataResponse<String>>.create { observer in
             Alamofire
-                .request(url, method: .get)
+                .request(urlRequest)
                 .responseString(encoding: .utf8) { observer.onNext($0) }
             return Disposables.create()
         }
+    }
+    
+    private func createGetUrlRequest(url: String) -> URLRequest? {
+        guard let urlObj = URL(string: url) else { return nil }
+
+        var urlRequest = URLRequest(url: urlObj,
+                                    cachePolicy: .reloadIgnoringLocalCacheData,
+                                    timeoutInterval: 5)
+        urlRequest.httpMethod = HTTPMethod.get.rawValue
+        
+        return urlRequest
     }
 }


### PR DESCRIPTION
サンプルJSONを書き換えてアップロードし直し、更新ボタンを押してもテスト用ラベルに反映されない現象が発生していた。
下記を参考に修正

https://www.yoheim.net/blog.php?q=20180306
https://developer.apple.com/documentation/foundation/urlrequest/2011415-httpmethod