### PR TITLE
ホームのタイムラインをリスト形式で表示できるようにした

### DIFF
--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		6723B28C2276970A0004FB3D /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B28B2276970A0004FB3D /* Status.swift */; };
 		6723B28E22769CAE0004FB3D /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B28D22769CAE0004FB3D /* Entity.swift */; };
 		6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B2912277DFD60004FB3D /* HomeTimelineViewModel.swift */; };
+		6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734D7F22279803200A19044 /* TweetSummaryCell.swift */; };
+		6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */; };
 		67666165227527FF004C886C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67666164227527FF004C886C /* AppDelegate.swift */; };
 		67666167227527FF004C886C /* HomeTimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67666166227527FF004C886C /* HomeTimelineViewController.swift */; };
 		6766616A227527FF004C886C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 67666168227527FF004C886C /* Main.storyboard */; };
@@ -58,6 +60,8 @@
 		6723B28B2276970A0004FB3D /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
 		6723B28D22769CAE0004FB3D /* Entity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		6723B2912277DFD60004FB3D /* HomeTimelineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTimelineViewModel.swift; sourceTree = "<group>"; };
+		6734D7F22279803200A19044 /* TweetSummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryCell.swift; sourceTree = "<group>"; };
+		6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryDataSource.swift; sourceTree = "<group>"; };
 		67666161227527FF004C886C /* NyanNyanEngine.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NyanNyanEngine.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		67666164227527FF004C886C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		67666166227527FF004C886C /* HomeTimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTimelineViewController.swift; sourceTree = "<group>"; };
@@ -158,6 +162,15 @@
 			path = api;
 			sourceTree = "<group>";
 		};
+		6734D7F12279800C00A19044 /* view */ = {
+			isa = PBXGroup;
+			children = (
+				6734D7F22279803200A19044 /* TweetSummaryCell.swift */,
+				6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */,
+			);
+			path = view;
+			sourceTree = "<group>";
+		};
 		67666158227527FF004C886C = {
 			isa = PBXGroup;
 			children = (
@@ -232,6 +245,7 @@
 		6767B0D422791CF9008913EA /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				6734D7F12279800C00A19044 /* view */,
 				6767B0D522791D1C008913EA /* homeTimeLine */,
 			);
 			path = ui;
@@ -476,6 +490,8 @@
 				6767B0D022791033008913EA /* TweetsRepository.swift in Sources */,
 				6723B28822768FCB0004FB3D /* UserMention.swift in Sources */,
 				6723B28C2276970A0004FB3D /* Status.swift in Sources */,
+				6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */,
+				6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */,
 				6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */,
 				6723B28A2276926B0004FB3D /* User.swift in Sources */,
 				6723B28E22769CAE0004FB3D /* Entity.swift in Sources */,

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -48,7 +48,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="112" id="vxd-9S-r1N"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -58,13 +58,13 @@
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
                                                     <rect key="frame" x="361" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -62,18 +62,18 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
-                                                    <rect key="frame" x="369" y="16" width="29" height="17"/>
+                                                    <rect key="frame" x="369" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="1bt-kp-0gS"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
-                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="top" id="AG4-gh-IQ4"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="AG4-gh-IQ4"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
                                                 <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="H74-yU-XnA"/>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="MEK-tK-vc2"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="20" symbolic="YES" id="f1f-Um-W1M"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -19,17 +19,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
-                                <rect key="frame" x="64" y="398" width="286" height="400"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="400" id="5TN-eI-ca0"/>
-                                </constraints>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="286" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e8B-hv-CC2" id="3yw-Hu-2gQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
@@ -50,9 +47,10 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="lwQ-LT-5Jj" secondAttribute="bottom" constant="64" id="R4M-jv-8A9"/>
-                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="rtz-Do-JXE"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="lwQ-LT-5Jj" secondAttribute="trailing" constant="64" id="zlg-oP-Ayk"/>
+                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="H2h-n9-A18"/>
+                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="R4M-jv-8A9"/>
+                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="rtz-Do-JXE"/>
+                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="zlg-oP-Ayk"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -18,20 +18,20 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="96" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="112" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="96"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="112"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e8B-hv-CC2" id="3yw-Hu-2gQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="95.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="111.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="72" y="45" width="326" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <rect key="frame" x="72" y="43.5" width="326" height="19.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -44,20 +44,20 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
-                                                    <rect key="frame" x="72" y="16" width="112" height="21"/>
+                                                    <rect key="frame" x="72" y="16" width="112" height="19.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="112" id="vxd-9S-r1N"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
-                                                    <rect key="frame" x="192" y="16" width="128" height="21"/>
+                                                    <rect key="frame" x="192" y="16" width="100" height="19.5"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="128" id="cKu-2r-aIA"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="cKu-2r-aIA"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -29,12 +29,6 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="111.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="72" y="43.5" width="326" height="19.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nsg-uh-dnN">
                                                     <rect key="frame" x="16" y="16" width="48" height="48"/>
                                                     <color key="backgroundColor" red="1" green="0.8338769587" blue="0.61603361320000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -65,6 +59,12 @@
                                                     <rect key="frame" x="361" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
+                                                    <rect key="frame" x="72" y="43.5" width="326" height="19.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -18,12 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXa-BO-uJC">
-                                <rect key="frame" x="64" y="152" width="286" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
                                 <rect key="frame" x="64" y="398" width="286" height="400"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -57,9 +51,6 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="lwQ-LT-5Jj" secondAttribute="bottom" constant="64" id="R4M-jv-8A9"/>
-                            <constraint firstItem="iXa-BO-uJC" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="64" id="Uhr-iW-qXe"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="iXa-BO-uJC" secondAttribute="trailing" constant="64" id="idJ-NE-KsX"/>
-                            <constraint firstItem="iXa-BO-uJC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="lzj-Av-hoA"/>
                             <constraint firstItem="lwQ-LT-5Jj" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="rtz-Do-JXE"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="lwQ-LT-5Jj" secondAttribute="trailing" constant="64" id="zlg-oP-Ayk"/>
                         </constraints>
@@ -70,7 +61,6 @@
                     </navigationItem>
                     <connections>
                         <outlet property="refreshButton" destination="qPq-1x-X5L" id="M8u-ap-M8C"/>
-                        <outlet property="testLabel" destination="iXa-BO-uJC" id="T5X-ys-cqw"/>
                         <outlet property="tweetList" destination="lwQ-LT-5Jj" id="Drh-V6-6L7"/>
                     </connections>
                 </viewController>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -29,9 +29,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="119.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="308" y="12" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
+                                                    <rect key="frame" x="96" y="53" width="302" height="42"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -65,10 +64,14 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="1bt-kp-0gS"/>
+                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
+                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" multiplier="2" id="FSq-N7-xUL"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="16" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
+                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="16" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
+                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="16" id="xlN-zg-45l"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>
                                             </constraints>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -87,7 +87,10 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" red="0.99215686270000003" green="0.96470588239999999" blue="0.89019607840000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
+                                            <outlet property="publishedAt" destination="PEj-Gh-Mzy" id="g4k-gb-v8N"/>
                                             <outlet property="tweetBody" destination="tUf-t7-w8I" id="Eh8-hA-cEo"/>
+                                            <outlet property="userId" destination="A6H-dr-b3W" id="goy-Pn-ibU"/>
+                                            <outlet property="userName" destination="hpO-br-q46" id="aFd-jJ-xgw"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -30,7 +30,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="72" y="45" width="326" height="42"/>
+                                                    <rect key="frame" x="72" y="45" width="326" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -46,7 +46,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
                                                     <rect key="frame" x="72" y="16" width="112" height="21"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="112" id="vxd-9S-r1N"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="112" id="vxd-9S-r1N"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -55,7 +55,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
                                                     <rect key="frame" x="192" y="16" width="128" height="21"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="128" id="cKu-2r-aIA"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="128" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -66,9 +66,9 @@
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="1bt-kp-0gS"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
-                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" multiplier="2" id="FSq-N7-xUL"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="20" symbolic="YES" id="f1f-Um-W1M"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="8" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXa-BO-uJC">
-                                <rect key="frame" x="64" y="152" width="286" height="646"/>
+                                <rect key="frame" x="64" y="152" width="286" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -28,7 +28,6 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="iXa-BO-uJC" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="64" id="Uhr-iW-qXe"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="iXa-BO-uJC" secondAttribute="bottom" constant="64" id="hsd-aM-by0"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="iXa-BO-uJC" secondAttribute="trailing" constant="64" id="idJ-NE-KsX"/>
                             <constraint firstItem="iXa-BO-uJC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="lzj-Av-hoA"/>
                         </constraints>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -18,15 +18,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="120" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e8B-hv-CC2" id="3yw-Hu-2gQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="119.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
@@ -38,6 +38,7 @@
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nsg-uh-dnN">
                                                     <rect key="frame" x="16" y="16" width="64" height="64"/>
+                                                    <color key="backgroundColor" red="1" green="0.8338769587" blue="0.61603361320000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="64" id="Q0N-ev-ZA6"/>
                                                         <constraint firstAttribute="width" constant="64" id="gL7-xH-0zo"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
                                                     <rect key="frame" x="72" y="43.5" width="326" height="19.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nsg-uh-dnN">
@@ -49,7 +49,7 @@
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="112" id="vxd-9S-r1N"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
@@ -58,13 +58,13 @@
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
                                                     <rect key="frame" x="361" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -24,12 +24,22 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
+                                <rect key="frame" x="64" y="398" width="286" height="400"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="400" id="5TN-eI-ca0"/>
+                                </constraints>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="lwQ-LT-5Jj" secondAttribute="bottom" constant="64" id="R4M-jv-8A9"/>
                             <constraint firstItem="iXa-BO-uJC" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="64" id="Uhr-iW-qXe"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="iXa-BO-uJC" secondAttribute="trailing" constant="64" id="idJ-NE-KsX"/>
                             <constraint firstItem="iXa-BO-uJC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="lzj-Av-hoA"/>
+                            <constraint firstItem="lwQ-LT-5Jj" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="64" id="rtz-Do-JXE"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="lwQ-LT-5Jj" secondAttribute="trailing" constant="64" id="zlg-oP-Ayk"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -18,44 +18,44 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="120" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="96" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="120"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="96"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e8B-hv-CC2" id="3yw-Hu-2gQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="119.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="95.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="96" y="53" width="302" height="42"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
+                                                    <rect key="frame" x="72" y="45" width="326" height="42"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nsg-uh-dnN">
-                                                    <rect key="frame" x="16" y="16" width="64" height="64"/>
+                                                    <rect key="frame" x="16" y="16" width="48" height="48"/>
                                                     <color key="backgroundColor" red="1" green="0.8338769587" blue="0.61603361320000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="64" id="Q0N-ev-ZA6"/>
-                                                        <constraint firstAttribute="width" constant="64" id="gL7-xH-0zo"/>
+                                                        <constraint firstAttribute="height" constant="48" id="Q0N-ev-ZA6"/>
+                                                        <constraint firstAttribute="width" constant="48" id="gL7-xH-0zo"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
-                                                    <rect key="frame" x="96" y="16" width="160" height="21"/>
+                                                    <rect key="frame" x="72" y="16" width="112" height="21"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="160" id="vxd-9S-r1N"/>
+                                                        <constraint firstAttribute="width" constant="112" id="vxd-9S-r1N"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
-                                                    <rect key="frame" x="272" y="16" width="96" height="21"/>
+                                                    <rect key="frame" x="192" y="16" width="128" height="21"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="96" id="cKu-2r-aIA"/>
+                                                        <constraint firstAttribute="width" constant="128" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -67,12 +67,12 @@
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" multiplier="2" id="FSq-N7-xUL"/>
-                                                <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="16" id="PWp-Tf-vsk"/>
+                                                <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
-                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="16" id="gxj-kH-q6j"/>
+                                                <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="8" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>
-                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="16" id="xlN-zg-45l"/>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="8" id="xlN-zg-45l"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>
                                             </constraints>
                                         </tableViewCellContentView>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -62,7 +62,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
-                                                    <rect key="frame" x="369" y="18.5" width="29" height="17"/>
+                                                    <rect key="frame" x="361" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -72,14 +72,14 @@
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
                                                 <constraint firstItem="PEj-Gh-Mzy" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="AG4-gh-IQ4"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
-                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="H74-yU-XnA"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-24" id="H74-yU-XnA"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="MEK-tK-vc2"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="20" symbolic="YES" id="f1f-Um-W1M"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="8" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
-                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A6H-dr-b3W" secondAttribute="trailing" constant="32" id="rVr-lz-4dF"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A6H-dr-b3W" secondAttribute="trailing" constant="8" id="rVr-lz-4dF"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="8" id="xlN-zg-45l"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -30,6 +30,28 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="400" id="5TN-eI-ca0"/>
                                 </constraints>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="286" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e8B-hv-CC2" id="3yw-Hu-2gQ">
+                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
+                                                    <rect key="frame" x="55" y="12" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="tweetBody" destination="tUf-t7-w8I" id="Eh8-hA-cEo"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -49,6 +71,7 @@
                     <connections>
                         <outlet property="refreshButton" destination="qPq-1x-X5L" id="M8u-ap-M8C"/>
                         <outlet property="testLabel" destination="iXa-BO-uJC" id="T5X-ys-cqw"/>
+                        <outlet property="tweetList" destination="lwQ-LT-5Jj" id="Drh-V6-6L7"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="112" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="lwQ-LT-5Jj">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" red="0.99215686270000003" green="0.96470588239999999" blue="0.89019607840000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TweetSummaryCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TweetSummaryCell" id="e8B-hv-CC2" customClass="TweetSummaryCell" customModule="NyanNyanEngine" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="414" height="112"/>
@@ -85,6 +85,7 @@
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <color key="backgroundColor" red="0.99215686270000003" green="0.96470588239999999" blue="0.89019607840000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
                                             <outlet property="tweetBody" destination="tUf-t7-w8I" id="Eh8-hA-cEo"/>
                                         </connections>
@@ -92,7 +93,7 @@
                                 </prototypes>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.99215686274509807" green="0.96470588235294119" blue="0.8901960784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="lwQ-LT-5Jj" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="H2h-n9-A18"/>
                             <constraint firstItem="lwQ-LT-5Jj" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="R4M-jv-8A9"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -61,16 +61,25 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
+                                                    <rect key="frame" x="369" y="16" width="29" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="1bt-kp-0gS"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="top" id="AG4-gh-IQ4"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="H74-yU-XnA"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="20" symbolic="YES" id="f1f-Um-W1M"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="8" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A6H-dr-b3W" secondAttribute="trailing" constant="32" id="rVr-lz-4dF"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="8" id="xlN-zg-45l"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -30,13 +30,47 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUf-t7-w8I">
-                                                    <rect key="frame" x="55" y="12" width="42" height="21"/>
+                                                    <rect key="frame" x="308" y="12" width="42" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nsg-uh-dnN">
+                                                    <rect key="frame" x="16" y="16" width="64" height="64"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="64" id="Q0N-ev-ZA6"/>
+                                                        <constraint firstAttribute="width" constant="64" id="gL7-xH-0zo"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
+                                                    <rect key="frame" x="96" y="16" width="160" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="160" id="vxd-9S-r1N"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
+                                                    <rect key="frame" x="272" y="16" width="96" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="96" id="cKu-2r-aIA"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="1bt-kp-0gS"/>
+                                                <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
+                                                <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="16" id="PWp-Tf-vsk"/>
+                                                <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
+                                                <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="16" id="xlN-zg-45l"/>
+                                                <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="tweetBody" destination="tUf-t7-w8I" id="Eh8-hA-cEo"/>

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
@@ -31,6 +31,7 @@ class HomeTimelineViewController: UIViewController {
     
     @IBOutlet weak var testLabel: UILabel!
     @IBOutlet weak var refreshButton: UIBarButtonItem!
+    @IBOutlet weak var tweetList: UITableView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,6 +44,11 @@ class HomeTimelineViewController: UIViewController {
         output.statuses
             .map { $0?.first?.text ?? "shippai"}
             .bind(to: testLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        output.statuses
+            .flatMap{ $0.flatMap { Observable<[Status]>.just($0) } ?? Observable<[Status]>.empty() }
+            .bind(to: tweetList.rx.items(dataSource: TweetSummaryDataSource()))
             .disposed(by: disposeBag)
         
         input.refreshExecutedAt?.onNext("2019/04/30 12:12:12")

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
@@ -29,7 +29,6 @@ class HomeTimelineViewController: UIViewController {
         super.init(coder: aDecoder)
     }
     
-    @IBOutlet weak var testLabel: UILabel!
     @IBOutlet weak var refreshButton: UIBarButtonItem!
     @IBOutlet weak var tweetList: UITableView!
     
@@ -39,11 +38,6 @@ class HomeTimelineViewController: UIViewController {
         refreshButton.rx.tap
             .map { "9999/12/31 23:59:59" }
             .bind(to: input.refreshExecutedAt!)
-            .disposed(by: disposeBag)
-        
-        output.statuses
-            .map { $0?.first?.text ?? "shippai"}
-            .bind(to: testLabel.rx.text)
             .disposed(by: disposeBag)
         
         output.statuses

--- a/NyanNyanEngine/ui/view/TweetSummaryCell.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryCell.swift
@@ -9,5 +9,8 @@
 import UIKit
 
 class TweetSummaryCell: UITableViewCell {
+    @IBOutlet weak var userName: UILabel!
+    @IBOutlet weak var userId: UILabel!
+    @IBOutlet weak var publishedAt: UILabel!
     @IBOutlet weak var tweetBody: UILabel!
 }

--- a/NyanNyanEngine/ui/view/TweetSummaryCell.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryCell.swift
@@ -1,0 +1,13 @@
+//
+//  TweetSummaryCell.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/01.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import UIKit
+
+class TweetSummaryCell: UITableViewCell {
+    @IBOutlet weak var tweetBody: UILabel!
+}

--- a/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
@@ -1,0 +1,39 @@
+//
+//  TweetSummaryDataSource.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/01.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+class TweetSummaryDataSource: NSObject, UITableViewDataSource {
+    typealias Element = [Status]
+    
+    var _itemModels: [Status] = []
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return _itemModels.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "TweetSummaryCell", for: indexPath) as? TweetSummaryCell else {
+            return UITableViewCell()
+        }
+        let element = _itemModels[indexPath.row]
+        cell.tweetBody?.text = element.text
+        return cell
+    }
+}
+
+extension TweetSummaryDataSource: RxTableViewDataSourceType {
+    
+    func tableView(_ tableView: UITableView, observedEvent: Event<Element>) {
+        Binder(self) { datasource, element in
+            datasource._itemModels = element
+            tableView.reloadData()
+            }.on(observedEvent)
+    }
+}

--- a/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
@@ -23,6 +23,8 @@ class TweetSummaryDataSource: NSObject, UITableViewDataSource {
             return UITableViewCell()
         }
         let element = _itemModels[indexPath.row]
+        cell.userName?.text = element.user.name
+        cell.userId?.text = element.user.screenName
         cell.tweetBody?.text = element.text
         return cell
     }


### PR DESCRIPTION
`RxSwift` を使用しているプロジェクトで、モデルの更新が起きた時、どうやっていい感じで一覧の要素を更新するかは下記を参考にして作成。 cf3064e2
https://qiita.com/hironytic/items/71bc729abe73ab9f0879

また、 `rx.item` にいい感じでアンラップされたアイテムが欲しかったので、下記を参考に、オペレータとして`flatmap`を用いたアンラップの処理を追加。 cf3064e2
https://qiita.com/ryotapoi/items/925a74ed4df9cb351c32

ツイート本文は2行としたが、`UILabel`の高さを指定していると１行の時でも上下中央揃えが働いてしまい、左上詰めにならない問題があった。ので下記を参考に設定をした。 9edb864
https://qiita.com/musclemikiya/items/7981a18d4aa94dc88b85

テーマはSolarizedとし、フォントサイズは下記を参考に決定。 ec73c84
http://snippets.feb19.jp/?p=1632