### PR TITLE
一連のログイン操作を行った後、ホームタイムラインAPIから正常に情報を持ってこれるようにした

### DIFF
--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		679A5E60227B1F250043D0E1 /* ApiRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679A5E5F227B1F250043D0E1 /* ApiRequestFactory.swift */; };
 		679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679A5E64227B3B590043D0E1 /* PlistConnector.swift */; };
 		679A5E67227B3E960043D0E1 /* ApiKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 679A5E66227B3E960043D0E1 /* ApiKeys.plist */; };
+		67F88C0A227C2484004DF44A /* UserDefaultsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */; };
 		A3EF89A62D1B991E9600FCFA /* Pods_NyanNyanEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9151EC8B3866FB493C75F6A9 /* Pods_NyanNyanEngine.framework */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +89,7 @@
 		679A5E5F227B1F250043D0E1 /* ApiRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiRequestFactory.swift; sourceTree = "<group>"; };
 		679A5E64227B3B590043D0E1 /* PlistConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistConnector.swift; sourceTree = "<group>"; };
 		679A5E66227B3E960043D0E1 /* ApiKeys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ApiKeys.plist; sourceTree = "<group>"; };
+		67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsConnector.swift; sourceTree = "<group>"; };
 		6D8A98757771D333C6941F1B /* Pods-NyanNyanEngineTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngineTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngineTests/Pods-NyanNyanEngineTests.release.xcconfig"; sourceTree = "<group>"; };
 		6F7E9C80946FAE4B36BBC437 /* Pods-NyanNyanEngine.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngine.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngine/Pods-NyanNyanEngine.release.xcconfig"; sourceTree = "<group>"; };
 		9151EC8B3866FB493C75F6A9 /* Pods_NyanNyanEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NyanNyanEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -281,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				679A5E64227B3B590043D0E1 /* PlistConnector.swift */,
+				67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */,
 			);
 			path = dao;
 			sourceTree = "<group>";
@@ -525,6 +528,7 @@
 				6723B28C2276970A0004FB3D /* Status.swift in Sources */,
 				6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */,
 				6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */,
+				67F88C0A227C2484004DF44A /* UserDefaultsConnector.swift in Sources */,
 				679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */,
 				6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */,
 				6723B28A2276926B0004FB3D /* User.swift in Sources */,

--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6723B28C2276970A0004FB3D /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B28B2276970A0004FB3D /* Status.swift */; };
 		6723B28E22769CAE0004FB3D /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B28D22769CAE0004FB3D /* Entity.swift */; };
 		6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B2912277DFD60004FB3D /* HomeTimelineViewModel.swift */; };
+		672FA83E227BE17E00BAB1A7 /* AppDelegateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672FA83D227BE17E00BAB1A7 /* AppDelegateModel.swift */; };
 		6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734D7F22279803200A19044 /* TweetSummaryCell.swift */; };
 		6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */; };
 		67392B0D227AF07900D5E77C /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67392B0C227AF07900D5E77C /* AuthRepository.swift */; };
@@ -65,6 +66,7 @@
 		6723B28D22769CAE0004FB3D /* Entity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		6723B2912277DFD60004FB3D /* HomeTimelineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTimelineViewModel.swift; sourceTree = "<group>"; };
 		672FA83C227BC2C100BAB1A7 /* NyanNyanEngine.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NyanNyanEngine.entitlements; sourceTree = "<group>"; };
+		672FA83D227BE17E00BAB1A7 /* AppDelegateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateModel.swift; sourceTree = "<group>"; };
 		6734D7F22279803200A19044 /* TweetSummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryCell.swift; sourceTree = "<group>"; };
 		6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryDataSource.swift; sourceTree = "<group>"; };
 		67392B0C227AF07900D5E77C /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				67666173227527FF004C886C /* Info.plist */,
 				6766616B227527FF004C886C /* NyanNyanEngine.xcdatamodeld */,
 				679A5E66227B3E960043D0E1 /* ApiKeys.plist */,
+				672FA83D227BE17E00BAB1A7 /* AppDelegateModel.swift */,
 			);
 			path = NyanNyanEngine;
 			sourceTree = "<group>";
@@ -525,6 +528,7 @@
 				679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */,
 				6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */,
 				6723B28A2276926B0004FB3D /* User.swift in Sources */,
+				672FA83E227BE17E00BAB1A7 /* AppDelegateModel.swift in Sources */,
 				6723B28E22769CAE0004FB3D /* Entity.swift in Sources */,
 				6767B0D322791745008913EA /* ApiClient.swift in Sources */,
 				67666165227527FF004C886C /* AppDelegate.swift in Sources */,

--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		6723B28B2276970A0004FB3D /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
 		6723B28D22769CAE0004FB3D /* Entity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		6723B2912277DFD60004FB3D /* HomeTimelineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTimelineViewModel.swift; sourceTree = "<group>"; };
+		672FA83C227BC2C100BAB1A7 /* NyanNyanEngine.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NyanNyanEngine.entitlements; sourceTree = "<group>"; };
 		6734D7F22279803200A19044 /* TweetSummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryCell.swift; sourceTree = "<group>"; };
 		6734D7F4227982BE00A19044 /* TweetSummaryDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetSummaryDataSource.swift; sourceTree = "<group>"; };
 		67392B0C227AF07900D5E77C /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
@@ -205,6 +206,7 @@
 		67666163227527FF004C886C /* NyanNyanEngine */ = {
 			isa = PBXGroup;
 			children = (
+				672FA83C227BC2C100BAB1A7 /* NyanNyanEngine.entitlements */,
 				6767B0D422791CF9008913EA /* ui */,
 				6723B27F22767C680004FB3D /* model */,
 				67666164227527FF004C886C /* AppDelegate.swift */,
@@ -362,6 +364,11 @@
 				TargetAttributes = {
 					67666160227527FF004C886C = {
 						CreatedOnToolsVersion = 10.2.1;
+						SystemCapabilities = {
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
+						};
 					};
 					67666177227527FF004C886C = {
 						CreatedOnToolsVersion = 10.2.1;
@@ -700,6 +707,7 @@
 			baseConfigurationReference = 0F29B6DB666E02B7C3169F94 /* Pods-NyanNyanEngine.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = NyanNyanEngine/NyanNyanEngine.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K85M397W48;
 				INFOPLIST_FILE = NyanNyanEngine/Info.plist;
@@ -719,6 +727,7 @@
 			baseConfigurationReference = 6F7E9C80946FAE4B36BBC437 /* Pods-NyanNyanEngine.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = NyanNyanEngine/NyanNyanEngine.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = K85M397W48;
 				INFOPLIST_FILE = NyanNyanEngine/Info.plist;

--- a/NyanNyanEngine/AppDelegate.swift
+++ b/NyanNyanEngine/AppDelegate.swift
@@ -11,9 +11,15 @@ import CoreData
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    private let appDelegateModel = AppDelegateModel()
 
     var window: UIWindow?
 
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        guard let redirectedUrl = userActivity.webpageURL else { return true }
+        self.appDelegateModel.loginExecutedAt?.onNext(redirectedUrl)
+        return true
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/NyanNyanEngine/AppDelegateModel.swift
+++ b/NyanNyanEngine/AppDelegateModel.swift
@@ -1,0 +1,38 @@
+//
+//  AppDelegateModel.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/03.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+protocol AppDelegateModelInput: AnyObject {
+    var loginExecutedAt: AnyObserver<URL>? { get }
+}
+
+protocol AppDelegateModelOutput: AnyObject {
+    
+}
+
+final class AppDelegateModel: AppDelegateModelInput, AppDelegateModelOutput {
+    private let authRepository: BaseAuthRepository
+    private let disposeBag = DisposeBag()
+    
+    var loginExecutedAt: AnyObserver<URL>? = nil
+    
+    init(authRepository: BaseAuthRepository = AuthRepository.shared) {
+        self.authRepository = authRepository
+        
+        self.loginExecutedAt = AnyObserver<URL>() { [unowned self] redirectedUrl in
+            guard let url = redirectedUrl.element else { return }
+            self.authRepository
+                .downloadAccessToken(redirectedUrl: url)
+                .subscribe()
+                .disposed(by: self.disposeBag)
+        }
+    }
+
+}

--- a/NyanNyanEngine/NyanNyanEngine.entitlements
+++ b/NyanNyanEngine/NyanNyanEngine.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:nyannyanengine.firebaseapp.com</string>
+	</array>
+</dict>
+</plist>

--- a/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
+++ b/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
@@ -1,0 +1,22 @@
+//
+//  UserDefaultsConnector.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/03.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import Foundation
+
+protocol BaseUserDefaultsConnector {
+    func isRegistered(withKey: String) -> Bool
+}
+
+class UserDefaultsConnector: BaseUserDefaultsConnector {
+    static let shared = UserDefaultsConnector()
+    private init() { }
+    
+    func isRegistered(withKey: String) -> Bool {
+        return UserDefaults.standard.object(forKey: withKey) != nil
+    }
+}

--- a/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
+++ b/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol BaseUserDefaultsConnector {
     func registerString(key: String, value: String)
+    func getString(withKey: String) -> String?
     func isRegistered(withKey: String) -> Bool
 }
 
@@ -19,6 +20,10 @@ class UserDefaultsConnector: BaseUserDefaultsConnector {
     
     func isRegistered(withKey: String) -> Bool {
         return UserDefaults.standard.object(forKey: withKey) != nil
+    }
+    
+    func getString(withKey: String) -> String? {
+        return UserDefaults.standard.string(forKey: withKey)
     }
     
     func registerString(key: String, value: String) {

--- a/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
+++ b/NyanNyanEngine/model/dao/UserDefaultsConnector.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 protocol BaseUserDefaultsConnector {
+    func registerString(key: String, value: String)
     func isRegistered(withKey: String) -> Bool
 }
 
@@ -18,5 +19,9 @@ class UserDefaultsConnector: BaseUserDefaultsConnector {
     
     func isRegistered(withKey: String) -> Bool {
         return UserDefaults.standard.object(forKey: withKey) != nil
+    }
+    
+    func registerString(key: String, value: String) {
+        UserDefaults.standard.set(value, forKey: key)
     }
 }

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -11,6 +11,7 @@ import CryptoSwift
 
 protocol BaseApiRequestFactory: AnyObject {
     func createRequestTokenRequest() -> URLRequest?
+    func createAccessTokenRequest(redirectedUrl: URL) -> URLRequest?
 }
 
 class ApiRequestFactory: BaseApiRequestFactory {
@@ -27,6 +28,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
     
     private let accessTokenSecret = ""
     private let requestTokenApiUrl = "https://api.twitter.com/oauth/request_token"
+    private let accessTokenApiUrl = "https://api.twitter.com/oauth/access_token?"
     
     init(apiKey: String = "abcdefghijklMNOPQRSTU0123",
          apiSecret: String = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN",
@@ -50,6 +52,18 @@ class ApiRequestFactory: BaseApiRequestFactory {
         urlRequest.httpMethod = "POST"
         urlRequest.addValue(makeAuthorizationValue(), forHTTPHeaderField: "Authorization")
         
+        return urlRequest
+    }
+    
+    func createAccessTokenRequest(redirectedUrl: URL) -> URLRequest? {
+        guard let query = NSURLComponents(string: redirectedUrl.absoluteString)?.query,
+            let urlObj = URL(string: accessTokenApiUrl + query) else { return nil }
+        
+        var urlRequest = URLRequest(url: urlObj,
+                                    cachePolicy: .reloadIgnoringLocalCacheData,
+                                    timeoutInterval: 5)
+        
+        urlRequest.httpMethod = "POST"
         return urlRequest
     }
     

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -20,7 +20,8 @@ class ApiRequestFactory: BaseApiRequestFactory {
     private let oauthTimeStamp: String
     private let oauthNonce: String
     private let accessTokenSecret: String
-    
+    private let accessToken: String
+
     private let allowedCharacterSet: CharacterSet
     
     private let oauthCallBackUrl = "https://nyannyanengine.firebaseapp.com/authorized/"
@@ -35,12 +36,14 @@ class ApiRequestFactory: BaseApiRequestFactory {
          apiSecret: String = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN",
          oauthTimeStamp: String = "1234567890",
          oauthNonce: String = "0000",
-         accessTokenSecret: String = "") {
+         accessTokenSecret: String = "",
+         accessToken: String = "") {
         self.apiKey = apiKey
         self.apiSecret = apiSecret
         self.oauthTimeStamp = oauthTimeStamp
         self.oauthNonce = oauthNonce
         self.accessTokenSecret = accessTokenSecret
+        self.accessToken = accessToken
         
         var baseAllowed = CharacterSet.alphanumerics
         baseAllowed.insert(charactersIn: "-._~")
@@ -75,7 +78,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
                       (key: "oauth_nonce", value: oauthNonce),
                       (key: "oauth_signature_method", value: oauthSignatureMethod),
                       (key: "oauth_timestamp", value: oauthTimeStamp),
-                      (key: "oauth_token", value: UserDefaultsConnector.shared.getString(withKey: "oauth_token")!),
+                      (key: "oauth_token", value: accessToken),
                       (key: "oauth_version", value: oauthVersion)]
             .map { (key: $0.key, value: $0.value.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)!) }
         params.append((key: "oauth_signature", value: createSignature(params: params, requestMethod: "GET", apiUrl: homeTimelineApiUrl)))

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -75,7 +75,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
                       (key: "oauth_nonce", value: oauthNonce),
                       (key: "oauth_signature_method", value: oauthSignatureMethod),
                       (key: "oauth_timestamp", value: oauthTimeStamp),
-                      (key: "oauth_token", value: "kanriGamenKaraTottaTokenWoIreru"),
+                      (key: "oauth_token", value: UserDefaultsConnector.shared.getString(withKey: "oauth_token")!),
                       (key: "oauth_version", value: oauthVersion)]
             .map { (key: $0.key, value: $0.value.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)!) }
         params.append((key: "oauth_signature", value: createSignature(params: params, requestMethod: "GET", apiUrl: homeTimelineApiUrl)))

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -48,7 +48,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
     }
     
     func createRequestTokenRequest() -> URLRequest? {
-        guard let urlObj = URL(string: "https://nyannyanengine-ios-d.firebaseapp.com/oauth/request_token") else { return nil }
+        guard let urlObj = URL(string: requestTokenApiUrl) else { return nil }
         var urlRequest = URLRequest(url: urlObj,
                                     cachePolicy: .reloadIgnoringLocalCacheData,
                                     timeoutInterval: 5)

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -19,6 +19,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
     private let apiSecret: String
     private let oauthTimeStamp: String
     private let oauthNonce: String
+    private let accessTokenSecret: String
     
     private let allowedCharacterSet: CharacterSet
     
@@ -26,18 +27,19 @@ class ApiRequestFactory: BaseApiRequestFactory {
     private let oauthSignatureMethod = "HMAC-SHA1"
     private let oauthVersion = "1.0"
     
-    private let accessTokenSecret = ""
     private let requestTokenApiUrl = "https://api.twitter.com/oauth/request_token"
     private let accessTokenApiUrl = "https://api.twitter.com/oauth/access_token?"
     
     init(apiKey: String = "abcdefghijklMNOPQRSTU0123",
          apiSecret: String = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN",
          oauthTimeStamp: String = "1234567890",
-         oauthNonce: String = "0000") {
+         oauthNonce: String = "0000",
+         accessTokenSecret: String = "") {
         self.apiKey = apiKey
         self.apiSecret = apiSecret
         self.oauthTimeStamp = oauthTimeStamp
         self.oauthNonce = oauthNonce
+        self.accessTokenSecret = accessTokenSecret
         
         var baseAllowed = CharacterSet.alphanumerics
         baseAllowed.insert(charactersIn: "-._~")

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -21,7 +21,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
     
     private let allowedCharacterSet: CharacterSet
     
-    private let oauthCallBackUrl = "https://rhenium.ntetz.com/nyan-nyan-engine/authorized"
+    private let oauthCallBackUrl = "https://nyannyanengine.firebaseapp.com/authorized/"
     private let oauthSignatureMethod = "HMAC-SHA1"
     private let oauthVersion = "1.0"
     

--- a/NyanNyanEngine/model/net/ApiRequestFactory.swift
+++ b/NyanNyanEngine/model/net/ApiRequestFactory.swift
@@ -17,13 +17,14 @@ protocol BaseApiRequestFactory: AnyObject {
 class ApiRequestFactory: BaseApiRequestFactory {
     private let apiKey: String
     private let apiSecret: String
-    private let oauthTimeStamp: String
+    
     private let oauthNonce: String
     private let accessTokenSecret: String
     private let accessToken: String
-
+    
     private let allowedCharacterSet: CharacterSet
     
+    private let oauthTimeStamp = String(Int(NSDate().timeIntervalSince1970))
     private let oauthCallBackUrl = "https://nyannyanengine.firebaseapp.com/authorized/"
     private let oauthSignatureMethod = "HMAC-SHA1"
     private let oauthVersion = "1.0"
@@ -34,13 +35,11 @@ class ApiRequestFactory: BaseApiRequestFactory {
     
     init(apiKey: String = "abcdefghijklMNOPQRSTU0123",
          apiSecret: String = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN",
-         oauthTimeStamp: String = "1234567890",
          oauthNonce: String = "0000",
          accessTokenSecret: String = "",
          accessToken: String = "") {
         self.apiKey = apiKey
         self.apiSecret = apiSecret
-        self.oauthTimeStamp = oauthTimeStamp
         self.oauthNonce = oauthNonce
         self.accessTokenSecret = accessTokenSecret
         self.accessToken = accessToken
@@ -96,7 +95,7 @@ class ApiRequestFactory: BaseApiRequestFactory {
                                     timeoutInterval: 5)
         urlRequest.httpMethod = "GET"
         urlRequest.addValue(headerValue, forHTTPHeaderField: "Authorization")
-
+        
         return urlRequest
     }
     

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 protocol BaseAuthRepository: AnyObject {
     func getRequestToken() -> Observable<URL>
+    func downloadAccessToken(redirectedUrl: URL) -> Observable<Bool>
 }
 
 class AuthRepository: BaseAuthRepository {
@@ -30,6 +31,16 @@ class AuthRepository: BaseAuthRepository {
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toAuthTokenValue(data: $0) }
             .flatMap { $0.flatMap {Observable<URL>.just($0)} ?? Observable<URL>.empty() }
+    }
+    
+    func downloadAccessToken(redirectedUrl: URL) -> Observable<Bool> {
+        guard let urlRequest = ApiRequestFactory().createAccessTokenRequest(redirectedUrl: redirectedUrl) else { return Observable<Bool>.empty() }
+        return self.apiClient
+            .postResponse(urlRequest: urlRequest)
+            .map { [unowned self] in
+                print(String(data: $0!, encoding: .utf8))
+            }
+            .map { false }
     }
     
     private func toAuthTokenValue(data: Data?) -> URL? {

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -29,7 +29,7 @@ class AuthRepository: BaseAuthRepository {
     func getRequestToken() -> Observable<URL> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: "1556750456", oauthNonce: "0000").createRequestTokenRequest() else { return Observable<URL>.empty() }
+            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000").createRequestTokenRequest() else { return Observable<URL>.empty() }
         return self.apiClient
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toAuthTokenValue(data: $0) }
@@ -59,6 +59,7 @@ class AuthRepository: BaseAuthRepository {
     
     private func saveTokens(accessTokenApiResponseQuery: [URLQueryItem]) {
         accessTokenApiResponseQuery.forEach { item in
+            print(item)
             guard let value = item.value else { return }
             self.userDefaultsConnector.registerString(key: item.name, value: value)
         }

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -18,9 +18,12 @@ class AuthRepository: BaseAuthRepository {
     static let shared = AuthRepository()
     
     private let apiClient: BaseApiClient
+    private let userDefaultsConnector: BaseUserDefaultsConnector
     
-    private init(apiClient: BaseApiClient = ApiClient.shared) {
+    private init(apiClient: BaseApiClient = ApiClient.shared,
+                 userDefaultsConnector: BaseUserDefaultsConnector = UserDefaultsConnector.shared) {
         self.apiClient = apiClient
+        self.userDefaultsConnector = userDefaultsConnector
     }
     
     func getRequestToken() -> Observable<URL> {

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -48,7 +48,7 @@ class AuthRepository: BaseAuthRepository {
     private func toAuthTokenValue(data: Data?) -> URL? {
         guard let d = data,
             let str = String(data: d, encoding: .utf8) else { return nil }
-        return URL(string: "https://api.twitter.com/oauth/authenticate?" + str)
+        return URL(string: "https://api.twitter.com/oauth/authorize?" + str)
     }
     
     private func parseTokens(accessTokenApiResponse: Data?) -> [URLQueryItem]? {

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -31,7 +31,6 @@ class AuthRepository: BaseAuthRepository {
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
             let urlRequest = ApiRequestFactory(apiKey: apiKey,
                                                apiSecret: apiSecret,
-                                               oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)),
                                                oauthNonce: "0000").createRequestTokenRequest() else { return Observable<URL>.empty() }
         return self.apiClient
             .postResponse(urlRequest: urlRequest)

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -29,7 +29,10 @@ class AuthRepository: BaseAuthRepository {
     func getRequestToken() -> Observable<URL> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000").createRequestTokenRequest() else { return Observable<URL>.empty() }
+            let urlRequest = ApiRequestFactory(apiKey: apiKey,
+                                               apiSecret: apiSecret,
+                                               oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)),
+                                               oauthNonce: "0000").createRequestTokenRequest() else { return Observable<URL>.empty() }
         return self.apiClient
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toAuthTokenValue(data: $0) }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -29,7 +29,9 @@ class TweetsRepository: BaseTweetsRepository {
     func getHomeTimeLine() -> Observable<[Status]?> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret")!, accessToken: UserDefaultsConnector.shared.getString(withKey: "oauth_token")!).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
+            let accessToken = UserDefaultsConnector.shared.getString(withKey: "oauth_token"),
+            let accessTokenSecret = UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret"),
+            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: accessTokenSecret, accessToken: accessToken).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
         
         return self.apiClient
             .postResponse(urlRequest: urlRequest)

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -29,7 +29,7 @@ class TweetsRepository: BaseTweetsRepository {
     func getHomeTimeLine() -> Observable<[Status]?> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret")!).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
+            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret")!, accessToken: UserDefaultsConnector.shared.getString(withKey: "oauth_token")!).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
         
         return self.apiClient
             .postResponse(urlRequest: urlRequest)

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -29,7 +29,7 @@ class TweetsRepository: BaseTweetsRepository {
     func getHomeTimeLine() -> Observable<[Status]?> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: "kanriGamenKaraTottaSecretWoIreru").createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
+            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret")!).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
         
         return self.apiClient
             .postResponse(urlRequest: urlRequest)

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 protocol BaseTweetsRepository: AnyObject {
+    func isLoggedIn() -> Bool
     func getHomeTimeLine() -> Observable<[Status]?>
 }
 
@@ -17,15 +18,22 @@ class TweetsRepository: BaseTweetsRepository {
     static let shared = TweetsRepository()
     
     private let apiClient: BaseApiClient
+    private let userDefaultsConnector: BaseUserDefaultsConnector
     
-    private init(apiClient: BaseApiClient = ApiClient.shared) {
+    private init(apiClient: BaseApiClient = ApiClient.shared,
+                 userDefaultsConnector: BaseUserDefaultsConnector = UserDefaultsConnector.shared) {
         self.apiClient = apiClient
+        self.userDefaultsConnector = userDefaultsConnector
     }
     
     func getHomeTimeLine() -> Observable<[Status]?> {
         return self.apiClient
             .getResponse(url: "https://nyannyanengine-ios-d.firebaseapp.com/1.1/statuses/home_timeline.json")
             .map { [unowned self] in self.toStatuses(data: $0) }
+    }
+    
+    func isLoggedIn() -> Bool {
+        return userDefaultsConnector.isRegistered(withKey: "oauth_token")
     }
     
     private func toStatuses(data: Data?) -> [Status]? {

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -31,7 +31,12 @@ class TweetsRepository: BaseTweetsRepository {
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
             let accessToken = UserDefaultsConnector.shared.getString(withKey: "oauth_token"),
             let accessTokenSecret = UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret"),
-            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: accessTokenSecret, accessToken: accessToken).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
+            let urlRequest = ApiRequestFactory(apiKey: apiKey,
+                                               apiSecret: apiSecret,
+                                               oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)),
+                                               oauthNonce: "0000",
+                                               accessTokenSecret: accessTokenSecret,
+                                               accessToken: accessToken).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
         
         return self.apiClient
             .postResponse(urlRequest: urlRequest)

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -33,7 +33,6 @@ class TweetsRepository: BaseTweetsRepository {
             let accessTokenSecret = UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret"),
             let urlRequest = ApiRequestFactory(apiKey: apiKey,
                                                apiSecret: apiSecret,
-                                               oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)),
                                                oauthNonce: "0000",
                                                accessTokenSecret: accessTokenSecret,
                                                accessToken: accessToken).createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -27,8 +27,12 @@ class TweetsRepository: BaseTweetsRepository {
     }
     
     func getHomeTimeLine() -> Observable<[Status]?> {
+        guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
+            let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
+            let urlRequest = ApiRequestFactory(apiKey: apiKey, apiSecret: apiSecret, oauthTimeStamp: String(Int(NSDate().timeIntervalSince1970)), oauthNonce: "0000", accessTokenSecret: "kanriGamenKaraTottaSecretWoIreru").createHomeTimelineRequest() else { return Observable<[Status]?>.empty() }
+        
         return self.apiClient
-            .getResponse(url: "https://nyannyanengine-ios-d.firebaseapp.com/1.1/statuses/home_timeline.json")
+            .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toStatuses(data: $0) }
     }
     


### PR DESCRIPTION
下記記事が大変参考になった

## ユニバーサルリンク

- https://dev.classmethod.jp/smartphone/universal-links/

## キー永続化

- https://qiita.com/KokiEnomoto/items/c79c7f3793a244246fcf

## ログインフロー、

###  `request_token` -> `authorize` -> `access_token` の流れ

- https://syncer.jp/Web/API/Twitter/REST_API/
- https://syncer.jp/Web/API/Twitter/REST_API/GET/statuses/home_timeline/

### HMAC_SHA1署名の確認ポイント
- http://westplain.sakuraweb.com/translate/twitter/Documentation/OAuth/Overview/Creating-a-signature.cgi

### クエリの操作
- https://qiita.com/kakipo/items/7a59ef70ace716145b38

close #16