### PR TITLE
ログインでリダイレクトされた後、更新ボタンを押すことでツイートリストが更新されるようにした

### DIFF
--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import RxSwift
+import RxRelay
 
 protocol HomeTimelineViewModelInput: AnyObject {
     //TODO: 後々、日付型っぽいやつにする
@@ -33,7 +34,7 @@ final class HomeTimelineViewModel: HomeTimelineViewModelInput, HomeTimelineViewM
         self.tweetsRepository = tweetsRepository
         self.authRepository = authRepository
         
-        let _statuses = BehaviorSubject<[Status]?>(value: nil)
+        let _statuses = BehaviorRelay<[Status]?>(value: nil)
         self.statuses = _statuses.asObservable()
         
         self.refreshExecutedAt = AnyObserver<String>() { [unowned self] updatedAt in


### PR DESCRIPTION
ログイン後、更新ボタンを押してもツイートリストが更新されない不具合があった。

更新ボタンを押した時、取得したてのトークンを使って通信できていたし、 `_status` も更新されていた。
なお、ログイン前や、ログイン後もタスクキルした後だと現象は発生しなかった。

加えて、下記記事を参考に、 `TweetSummaryDataSource` の `tableView(_ tableView: indexPath:)` にログを仕込んでみた。やっぱりログイン直後はここまで処理が行かない。
https://teratail.com/questions/60123
なので、 `HomeTimelineViewController` の下記記述から始まるデータのバインディングが怪しそうだと判断

```swift
output.statuses
     .flatMap{ $0.flatMap { Observable<[Status]>.just($0) } ?? Observable<[Status]>.empty() }
    .bind(to: tweetList.rx.items(dataSource: TweetSummaryDataSource()))
    .disposed(by: disposeBag)

```

ここにイベントを送ってくるのは `HomeTimelineViewModel` 。 `.init()` に下記の検査を書いて、 `refreshExecutedAt` に向けてイベントを飛ばしたが、 `更新されちゃったよ` 表示はログイン直後は発生しなかった。

```swift
let _statuses = BehaviorSubject<[Status]?>(value: nil)
self.refreshExecutedAt = AnyObserver<String>() { [unowned self] updatedAt in
    self.tweetsRepository
        .getHomeTimeLine()
        .map {
            print("更新のイベントを投げちゃうよ")
            return $0 ?? []
        }
        .bind(to: _statuses)
        .disposed(by: self.disposeBag)
    print(updatedAt.element)
}

_statuses.subscribe() {
    print("更新されちゃったよ")
}.disposed(by: disposeBag)
```

 `BehaviorSubject` が怪しいなと思ったので、 `BehaviorSubject` のラッパーとして紹介されていた `BehaviorRelay` について調べてたら下記記事を発見。メモリがどうこうと書いてあったので試してみたら、偶然直った。
とても助かった。

https://qiita.com/summer-hues/items/7ffe707c2f3097b44297