### PR TITLE
ログイン時、自動的にログイン後ユーザーのツイートリストが表示されるようにした

### DIFF
--- a/NyanNyanEngine/AppDelegateModel.swift
+++ b/NyanNyanEngine/AppDelegateModel.swift
@@ -19,17 +19,25 @@ protocol AppDelegateModelOutput: AnyObject {
 
 final class AppDelegateModel: AppDelegateModelInput, AppDelegateModelOutput {
     private let authRepository: BaseAuthRepository
+    private let tweetsRepository: BaseTweetsRepository
+
     private let disposeBag = DisposeBag()
     
     var loginExecutedAt: AnyObserver<URL>? = nil
-    
-    init(authRepository: BaseAuthRepository = AuthRepository.shared) {
+
+    init(authRepository: BaseAuthRepository = AuthRepository.shared,
+         tweetsRepository: BaseTweetsRepository = TweetsRepository.shared) {
         self.authRepository = authRepository
+        self.tweetsRepository = tweetsRepository
         
         self.loginExecutedAt = AnyObserver<URL>() { [unowned self] redirectedUrl in
             guard let url = redirectedUrl.element else { return }
             self.authRepository
-                .downloadAccessToken(redirectedUrl: url)
+                .downloadAccessToken(redirectedUrl: url) {
+                    self.tweetsRepository
+                        .buttonRefreshExecutedAt?
+                        .onNext("")
+                }
                 .subscribe()
                 .disposed(by: self.disposeBag)
         }

--- a/NyanNyanEngine/AppDelegateModel.swift
+++ b/NyanNyanEngine/AppDelegateModel.swift
@@ -34,6 +34,10 @@ final class AppDelegateModel: AppDelegateModelInput, AppDelegateModelOutput {
             guard let url = redirectedUrl.element else { return }
             self.authRepository
                 .downloadAccessToken(redirectedUrl: url) {
+                    self.authRepository
+                        .loginExecutedAt?
+                        .onNext("")
+                    
                     self.tweetsRepository
                         .buttonRefreshExecutedAt?
                         .onNext("")

--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -45,14 +45,6 @@ class AuthRepository: BaseAuthRepository {
         }
     }
     
-    func getCurrentUser() -> Observable<String> {
-        let currentUser = userDefaultsConnector.getString(withKey: "screen_name") ?? "にゃんにゃんエンジン"
-        return Observable<String>.create { observer in
-            observer.onNext(currentUser)
-            return Disposables.create()
-        }
-    }
-    
     func getRequestToken() -> Observable<URL> {
         guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
             let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
@@ -74,6 +66,14 @@ class AuthRepository: BaseAuthRepository {
             .map { [unowned self] in self.saveTokens(accessTokenApiResponseQuery: $0 ?? [])}
             .map (modelUpdateLogic)
             .map { true }
+    }
+    
+    private func getCurrentUser() -> Observable<String> {
+        let currentUser = userDefaultsConnector.getString(withKey: "screen_name") ?? "にゃんにゃんエンジン"
+        return Observable<String>.create { observer in
+            observer.onNext(currentUser)
+            return Disposables.create()
+        }
     }
     
     private func toAuthTokenValue(data: Data?) -> URL? {

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -13,7 +13,6 @@ import RxRelay
 protocol BaseTweetsRepository: AnyObject {
     func isLoggedIn() -> Bool
     func getHomeTimeLine(uiRefreshControl: UIRefreshControl?) -> Observable<[Status]?>
-    func getCurrentUser() -> Observable<String>
     
     var statuses: Observable<[Status]?> { get }
     var buttonRefreshExecutedAt: AnyObserver<String>? { get }
@@ -73,14 +72,6 @@ class TweetsRepository: BaseTweetsRepository {
         return self.apiClient
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toStatuses(data: $0) }
-    }
-    
-    func getCurrentUser() -> Observable<String> {
-        let tekitou = userDefaultsConnector.getString(withKey: "screen_name") ?? "にゃんにゃんエンジン"
-        return Observable<String>.create { observer in
-            observer.onNext(tekitou)
-            return Disposables.create()
-        }
     }
     
     func isLoggedIn() -> Bool {

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -11,7 +11,6 @@ import RxSwift
 import RxRelay
 
 protocol BaseTweetsRepository: AnyObject {
-    func isLoggedIn() -> Bool
     func getHomeTimeLine(uiRefreshControl: UIRefreshControl?) -> Observable<[Status]?>
     
     var statuses: Observable<[Status]?> { get }
@@ -72,10 +71,6 @@ class TweetsRepository: BaseTweetsRepository {
         return self.apiClient
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toStatuses(data: $0) }
-    }
-    
-    func isLoggedIn() -> Bool {
-        return userDefaultsConnector.isRegistered(withKey: "oauth_token")
     }
     
     private func toStatuses(data: Data?) -> [Status]? {

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -28,7 +28,7 @@ class TweetsRepository: BaseTweetsRepository {
     let statuses: Observable<[Status]?>
     var buttonRefreshExecutedAt: AnyObserver<String>? = nil
     var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl?>? = nil
-
+    
     private init(apiClient: BaseApiClient = ApiClient.shared,
                  userDefaultsConnector: BaseUserDefaultsConnector = UserDefaultsConnector.shared) {
         self.apiClient = apiClient
@@ -39,8 +39,8 @@ class TweetsRepository: BaseTweetsRepository {
         
         self.buttonRefreshExecutedAt = AnyObserver<String> { [unowned self] updatedAt in
             self.getHomeTimeLine()
-            .bind(to: _statuses)
-            .disposed(by: self.disposeBag)
+                .bind(to: _statuses)
+                .disposed(by: self.disposeBag)
         }
         
         self.pullToRefreshExecutedAt = AnyObserver<UIRefreshControl?> { [unowned self] uiRefreshControl in
@@ -50,8 +50,8 @@ class TweetsRepository: BaseTweetsRepository {
                     uiRefreshControl.element??.endRefreshing()
                     return $0 ?? []
                 }
-            .bind(to: _statuses)
-            .disposed(by: self.disposeBag)
+                .bind(to: _statuses)
+                .disposed(by: self.disposeBag)
         }
     }
     

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -8,23 +8,53 @@
 
 import Foundation
 import RxSwift
+import RxRelay
 
 protocol BaseTweetsRepository: AnyObject {
     func isLoggedIn() -> Bool
     func getHomeTimeLine(uiRefreshControl: UIRefreshControl?) -> Observable<[Status]?>
     func getCurrentUser() -> Observable<String>
+    
+    var statuses: Observable<[Status]?> { get }
+    var buttonRefreshExecutedAt: AnyObserver<String>? { get }
+    var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl?>? { get }
 }
 
 class TweetsRepository: BaseTweetsRepository {
     static let shared = TweetsRepository()
     
+    private let disposeBag = DisposeBag()
     private let apiClient: BaseApiClient
     private let userDefaultsConnector: BaseUserDefaultsConnector
     
+    let statuses: Observable<[Status]?>
+    var buttonRefreshExecutedAt: AnyObserver<String>? = nil
+    var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl?>? = nil
+
     private init(apiClient: BaseApiClient = ApiClient.shared,
                  userDefaultsConnector: BaseUserDefaultsConnector = UserDefaultsConnector.shared) {
         self.apiClient = apiClient
         self.userDefaultsConnector = userDefaultsConnector
+        
+        let _statuses = BehaviorRelay<[Status]?>(value: nil)
+        self.statuses = _statuses.asObservable()
+        
+        self.buttonRefreshExecutedAt = AnyObserver<String> { [unowned self] updatedAt in
+            self.getHomeTimeLine()
+            .bind(to: _statuses)
+            .disposed(by: self.disposeBag)
+        }
+        
+        self.pullToRefreshExecutedAt = AnyObserver<UIRefreshControl?> { [unowned self] uiRefreshControl in
+            self.getHomeTimeLine()
+                .map {
+                    sleep(1)
+                    uiRefreshControl.element??.endRefreshing()
+                    return $0 ?? []
+                }
+            .bind(to: _statuses)
+            .disposed(by: self.disposeBag)
+        }
     }
     
     func getHomeTimeLine(uiRefreshControl: UIRefreshControl? = nil) -> Observable<[Status]?> {

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import RxSwift
-import RxRelay
 
 protocol HomeTimelineViewModelInput: AnyObject {
     //TODO: 後々、日付型っぽいやつにする
@@ -38,27 +37,23 @@ final class HomeTimelineViewModel: HomeTimelineViewModelInput, HomeTimelineViewM
         self.tweetsRepository = tweetsRepository
         self.authRepository = authRepository
         
-        let _currentUser = BehaviorRelay<String>(value: "にゃんにゃんエンジン")
-        self.currentUser = _currentUser.asObservable()
-        
+        self.currentUser = authRepository.currentUser
         self.statuses = tweetsRepository.statuses
         
         self.buttonRefreshExecutedAt = AnyObserver<String>() { [unowned self] updatedAt in
-            self.tweetsRepository
-                .getCurrentUser()
-                .bind(to: _currentUser)
-                .disposed(by: self.disposeBag)
+            self.authRepository
+                .loginExecutedAt?
+                .onNext(updatedAt.element ?? "")
             
             self.tweetsRepository
                 .buttonRefreshExecutedAt?
                 .onNext(updatedAt.element ?? "")
         }
-
+        
         self.pullToRefreshExecutedAt = AnyObserver<UIRefreshControl>() { [unowned self] uiRefreshControl in
-            self.tweetsRepository
-                .getCurrentUser()
-                .bind(to: _currentUser)
-                .disposed(by: self.disposeBag)
+            self.authRepository
+                .loginExecutedAt?
+                .onNext("")
             
             self.tweetsRepository
                 .pullToRefreshExecutedAt?


### PR DESCRIPTION
これまで、ログインしてリダイレクトされた後処理が投げられる `AppDelegate` は、ツイートリストにバインドされているアイテムの参照を知ることがこれまではできなかった。その参照は、`HomeTimelineViewModel` のプロパティとして存在していたためである。
`AppDelegate` ならびに `AppDelegateModel` から `HomeTimelineViewModel` のプロパティを持ってくるのは設計上綺麗ではないのでやりたくない。

なので、ツイートリストにバインドされているアイテムや、ユーザー名としてバインドされている文字列の参照を、 `***Repository` クラスに移した。

その結果、  `AppDelegateModel` を通して `AppDelegate` がバインドされている参照に向けて通知を送れるようになった。
したがって、ログイン画面からリダイレクトしただけでツイートリストやユーザー名が更新されるようになった。

下記が参考になった
http://www.kuma-de.com/blog/2017-10-18/7381

close #9