### PR TITLE
ツイートの表示が猫語になるようにした

### DIFF
--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		679A5E60227B1F250043D0E1 /* ApiRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679A5E5F227B1F250043D0E1 /* ApiRequestFactory.swift */; };
 		679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679A5E64227B3B590043D0E1 /* PlistConnector.swift */; };
 		679A5E67227B3E960043D0E1 /* ApiKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 679A5E66227B3E960043D0E1 /* ApiKeys.plist */; };
+		67D86EE0227FC5DB00965816 /* NyanNyan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D86EDF227FC5DB00965816 /* NyanNyan.swift */; };
 		67F88C0A227C2484004DF44A /* UserDefaultsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */; };
 		A3EF89A62D1B991E9600FCFA /* Pods_NyanNyanEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9151EC8B3866FB493C75F6A9 /* Pods_NyanNyanEngine.framework */; };
 /* End PBXBuildFile section */
@@ -91,6 +92,7 @@
 		679A5E5F227B1F250043D0E1 /* ApiRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiRequestFactory.swift; sourceTree = "<group>"; };
 		679A5E64227B3B590043D0E1 /* PlistConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistConnector.swift; sourceTree = "<group>"; };
 		679A5E66227B3E960043D0E1 /* ApiKeys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ApiKeys.plist; sourceTree = "<group>"; };
+		67D86EDF227FC5DB00965816 /* NyanNyan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NyanNyan.swift; sourceTree = "<group>"; };
 		67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsConnector.swift; sourceTree = "<group>"; };
 		6D8A98757771D333C6941F1B /* Pods-NyanNyanEngineTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngineTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngineTests/Pods-NyanNyanEngineTests.release.xcconfig"; sourceTree = "<group>"; };
 		6F7E9C80946FAE4B36BBC437 /* Pods-NyanNyanEngine.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngine.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngine/Pods-NyanNyanEngine.release.xcconfig"; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 			isa = PBXGroup;
 			children = (
 				6723B28222767C8B0004FB3D /* api */,
+				67D86EDF227FC5DB00965816 /* NyanNyan.swift */,
 			);
 			path = dataclass;
 			sourceTree = "<group>";
@@ -546,6 +549,7 @@
 				679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */,
 				6723B2922277DFD60004FB3D /* HomeTimelineViewModel.swift in Sources */,
 				6723B28A2276926B0004FB3D /* User.swift in Sources */,
+				67D86EE0227FC5DB00965816 /* NyanNyan.swift in Sources */,
 				672FA83E227BE17E00BAB1A7 /* AppDelegateModel.swift in Sources */,
 				670E3979227E4738002318AE /* LoadingStatusRepository.swift in Sources */,
 				6767B0D322791745008913EA /* ApiClient.swift in Sources */,

--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		084A3E64E6115529C8195800 /* Pods_NyanNyanEngineTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4077A070BC8D307547E44D6 /* Pods_NyanNyanEngineTests.framework */; };
 		670E3979227E4738002318AE /* LoadingStatusRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670E3978227E4738002318AE /* LoadingStatusRepository.swift */; };
 		670E397C227E7179002318AE /* DefaultNekosan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670E397B227E7179002318AE /* DefaultNekosan.swift */; };
+		670E397E227FB4F7002318AE /* NekosanConverterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670E397D227FB4F7002318AE /* NekosanConverterTest.swift */; };
+		670E3980227FB67C002318AE /* Nekosan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670E397F227FB67C002318AE /* Nekosan.swift */; };
 		6723B286227682F60004FB3D /* JsonDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B285227682F60004FB3D /* JsonDecodeTests.swift */; };
 		6723B28A2276926B0004FB3D /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B2892276926B0004FB3D /* User.swift */; };
 		6723B28C2276970A0004FB3D /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6723B28B2276970A0004FB3D /* Status.swift */; };
@@ -60,6 +62,8 @@
 		5CB14DB9062ED19CFBABD8AA /* Pods_NyanNyanEngineUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NyanNyanEngineUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		670E3978227E4738002318AE /* LoadingStatusRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingStatusRepository.swift; sourceTree = "<group>"; };
 		670E397B227E7179002318AE /* DefaultNekosan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNekosan.swift; sourceTree = "<group>"; };
+		670E397D227FB4F7002318AE /* NekosanConverterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NekosanConverterTest.swift; sourceTree = "<group>"; };
+		670E397F227FB67C002318AE /* Nekosan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nekosan.swift; sourceTree = "<group>"; };
 		6723B285227682F60004FB3D /* JsonDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonDecodeTests.swift; sourceTree = "<group>"; };
 		6723B2892276926B0004FB3D /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		6723B28B2276970A0004FB3D /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 			children = (
 				670E397A227E715F002318AE /* constant */,
 				6723B28122767C7F0004FB3D /* dataclass */,
+				670E397F227FB67C002318AE /* Nekosan.swift */,
 			);
 			path = entity;
 			sourceTree = "<group>";
@@ -234,6 +239,7 @@
 			children = (
 				6766617E227527FF004C886C /* Info.plist */,
 				6723B285227682F60004FB3D /* JsonDecodeTests.swift */,
+				670E397D227FB4F7002318AE /* NekosanConverterTest.swift */,
 			);
 			path = NyanNyanEngineTests;
 			sourceTree = "<group>";
@@ -532,6 +538,7 @@
 				67666167227527FF004C886C /* HomeTimelineViewController.swift in Sources */,
 				6767B0D022791033008913EA /* TweetsRepository.swift in Sources */,
 				6723B28C2276970A0004FB3D /* Status.swift in Sources */,
+				670E3980227FB67C002318AE /* Nekosan.swift in Sources */,
 				670E397C227E7179002318AE /* DefaultNekosan.swift in Sources */,
 				6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */,
 				6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */,
@@ -553,6 +560,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				670E397E227FB4F7002318AE /* NekosanConverterTest.swift in Sources */,
 				6723B286227682F60004FB3D /* JsonDecodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NyanNyanEngine/model/entity/Nekosan.swift
+++ b/NyanNyanEngine/model/entity/Nekosan.swift
@@ -1,0 +1,99 @@
+//
+//  Nekosan.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/06.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import Foundation
+import CryptoSwift
+
+struct Nekosan {
+    func createNekogo(sourceStr: String) -> String {
+        let nekogoSource = sourceStr.md5()
+        let nekogoBody = String(nekogoSource.prefix(3))
+            .reduce("") { $0 + getNekogoBody(sourceChar: $1) }
+        let nyankoSuffix = String(nekogoSource.prefix(1))
+            .reduce("") { $0 + getNekogoSuffix(sourceChar: $1) }
+        return nekogoBody + nyankoSuffix
+    }
+    
+    private func getNekogoBody(sourceChar: Character) -> String {
+        switch(sourceChar) {
+        case "0":
+            return "にゃん"
+        case "1":
+            return "にゃん"
+        case "2":
+            return "にゃお"
+        case "3":
+            return "にゃお"
+        case "4":
+            return "にゃー"
+        case "5":
+            return "にゃー"
+        case "6":
+            return "にゃ"
+        case "7":
+            return "にゃ"
+        case "8":
+            return "にゃ"
+        case "9":
+            return "にゃーん"
+        case "a":
+            return "にゃーん"
+        case "b":
+            return "にゃーお"
+        case "c":
+            return "にゃおーん"
+        case "d":
+            return "にゃーおん"
+        case "e":
+            return "にゃあ"
+        case "f":
+            return "にゃあ"
+        default:
+            return "ごろごろ"
+        }
+    }
+    
+    private func getNekogoSuffix(sourceChar: Character) -> String {
+        switch(sourceChar) {
+        case "0":
+            return ""
+        case "1":
+            return "😊"
+        case "2":
+            return "🙁"
+        case "3":
+            return ""
+        case "4":
+            return "🐤"
+        case "5":
+            return "🐳"
+        case "6":
+            return ""
+        case "7":
+            return "🐟"
+        case "8":
+            return "🐟"
+        case "9":
+            return "🏆"
+        case "a":
+            return ""
+        case "b":
+            return "🌈"
+        case "c":
+            return "🎊"
+        case "d":
+            return ""
+        case "e":
+            return ":)"
+        case "f":
+            return "XD"
+        default:
+            return "(^o^)"
+        }
+    }
+}

--- a/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
+++ b/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
@@ -7,58 +7,55 @@
 //
 
 struct DefaultNekosan {
-    let statuses: [Status] = [
-        Status(text: "にゃんにゃにゃおん\n(訳: ここは猫さんの世界)",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+    let nyanNyanStatuses: [NyanNyan] = [
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "にゃんにゃにゃおん\n(訳: ここは猫さんの世界)"),
         
-        Status(text: "にゃあにゃおーんにゃ\n(訳: 言葉がみんな猫語になるよ)",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "にゃあにゃおーんにゃ\n(訳: 言葉がみんな猫語になるよ)"),
         
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "にゃんにゃーにゃーお\n(訳: ツイッターでログインして)"),
         
-        Status(text: "にゃんにゃーにゃーお\n(訳: ツイッターでログインして)",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "にゃにゃんにゃ\n(訳: 一緒に楽しく遊ぼうよ)"),
         
-        Status(text: "にゃにゃんにゃ\n(訳: 一緒に楽しく遊ぼうよ)",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "🐟"),
         
-        Status(text: "🐟",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+        NyanNyan(profileUrl: nil,
+                 userName: "猫一＠起業家",
+                 userId: "neko_is_the_top",
+                 nekogo: "にゃーんにゃーにゃん"),
         
-        Status(text: "にゃーんにゃーにゃん",
-               user: User(name: "猫一＠起業家",
-                          screenName: "neko_is_the_top",
-                          profileImageUrlHttps: nil)),
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "にゃんこグリップ",
+                 userId: "sutaddoresu_nekosan",
+                 nekogo: "にゃあにゃんにゃー"),
         
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ニャン・ニャーンス I世",
+                 userId: "nyan_nyaaansu",
+                 nekogo: "にゃおにゃにゃおーん"),
         
-        Status(text: "にゃあにゃんにゃー",
-               user: User(name: "にゃんこグリップ",
-                          screenName: "sutaddoresu_nekosan",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
+        NyanNyan(profileUrl: nil,
+                 userName: "猫さんドロイド",
+                 userId: "neko_droid",
+                 nekogo: "にゃあにゃおにゃー"),
         
-        Status(text: "にゃおにゃにゃおーん",
-               user: User(name: "ニャン・ニャーンス I世",
-                          screenName: "nyan_nyaaansu",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
-        
-        Status(text: "にゃあにゃおにゃー",
-               user: User(name: "猫さんドロイド",
-                          screenName: "neko_droid",
-                          profileImageUrlHttps: nil)),
-        
-        Status(text: "にゃーんにゃおにゃー",
-               user: User(name: "ブーツキャット",
-                          screenName: "hosome_zubon",
-                          profileImageUrlHttps: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg")),
-        
-        ]
+        NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
+                 userName: "ブーツキャット",
+                 userId: "hosome_zubon",
+                 nekogo: "にゃーんにゃおにゃー"),
+    ]
 }

--- a/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
+++ b/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
@@ -1,0 +1,16 @@
+//
+//  NyanNyan.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/06.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import Foundation
+
+struct NyanNyan {
+    let profileUrl: String?
+    let userName: String
+    let userId: String
+    let nekogo: String
+}

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -87,7 +87,7 @@ class TweetsRepository: BaseTweetsRepository {
         return rawTweets?.map {
             NyanNyan(profileUrl: $0.user.profileImageUrlHttps,
                      userName: $0.user.name,
-                     userId: $0.user.screenName,
+                     userId: ("@" + $0.user.screenName),
                      nekogo: Nekosan().createNekogo(sourceStr: $0.text))
         } ?? []
     }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -73,6 +73,10 @@ class TweetsRepository: BaseTweetsRepository {
         return self.apiClient
             .postResponse(urlRequest: urlRequest)
             .map { [unowned self] in self.toStatuses(data: $0) }
+            .map { [unowned self] res in
+                print(self.toNyanyan(rawTweets: res))
+                return res
+        }
     }
     
     private func toStatuses(data: Data?) -> [Status]? {
@@ -80,5 +84,14 @@ class TweetsRepository: BaseTweetsRepository {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         guard let d = data else { return nil }
         return try? decoder.decode([Status].self, from: d)
+    }
+    
+    private func toNyanyan(rawTweets: [Status]?) -> [NyanNyan] {
+        return rawTweets?.map {
+            NyanNyan(profileUrl: $0.user.profileImageUrlHttps,
+                     userName: $0.user.name,
+                     userId: $0.user.screenName,
+                     nekogo: Nekosan().createNekogo(sourceStr: $0.text))
+        } ?? []
     }
 }

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
@@ -52,8 +52,8 @@ class HomeTimelineViewController: UIViewController {
             .bind(to: input.buttonRefreshExecutedAt!)
             .disposed(by: disposeBag)
         
-        output.statuses
-            .flatMap{ $0.flatMap { Observable<[Status]>.just($0) } ?? Observable<[Status]>.empty() }
+        output.nyanNyanStatuses
+            .flatMap{ $0.flatMap { Observable<[NyanNyan]>.just($0) } ?? Observable<[NyanNyan]>.empty() }
             .bind(to: tweetList.rx.items(dataSource: TweetSummaryDataSource()))
             .disposed(by: disposeBag)
         

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewModel.swift
@@ -17,7 +17,7 @@ protocol HomeTimelineViewModelInput: AnyObject {
 }
 
 protocol HomeTimelineViewModelOutput: AnyObject {
-    var statuses: Observable<[Status]?> { get }
+    var nyanNyanStatuses: Observable<[NyanNyan]?> { get }
     var currentUser: Observable<String> { get }
     var isLoading: Observable<Bool> { get }
     var isLoggedIn: Observable<Bool>? { get }
@@ -33,7 +33,7 @@ final class HomeTimelineViewModel: HomeTimelineViewModelInput, HomeTimelineViewM
     var buttonRefreshExecutedAt: AnyObserver<String>? = nil
     var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl>? = nil
     let currentUser: Observable<String>
-    let statuses: Observable<[Status]?>
+    let nyanNyanStatuses: Observable<[NyanNyan]?>
     let isLoading: Observable<Bool>
     let isLoggedIn: Observable<Bool>?
     
@@ -45,7 +45,7 @@ final class HomeTimelineViewModel: HomeTimelineViewModelInput, HomeTimelineViewM
         self.loadingStatusRepository = loadingStatusRepository
         
         self.currentUser = authRepository.currentUser
-        self.statuses = tweetsRepository.statuses
+        self.nyanNyanStatuses = tweetsRepository.nyanNyanStatuses
         self.isLoading = loadingStatusRepository.isLoading
         self.isLoggedIn = authRepository.isLoggedIn
         

--- a/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
@@ -12,9 +12,9 @@ import RxSwift
 import Nuke
 
 class TweetSummaryDataSource: NSObject, UITableViewDataSource {
-    typealias Element = [Status]
+    typealias Element = [NyanNyan]
     
-    var _itemModels: [Status] = []
+    var _itemModels: [NyanNyan] = []
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return _itemModels.count
     }
@@ -26,15 +26,15 @@ class TweetSummaryDataSource: NSObject, UITableViewDataSource {
         
         let element = _itemModels[indexPath.row]
         
-        element.user.profileImageUrlHttps
+        element.profileUrl
             .flatMap({ URL(string: $0) })
             .map({ Nuke.loadImage(with: $0, into: cell.userImage)
                 return
             })
         
-        cell.userName?.text = element.user.name
-        cell.userId?.text = element.user.screenName
-        cell.tweetBody?.text = element.text
+        cell.userName?.text = element.userName
+        cell.userId?.text = element.userId
+        cell.tweetBody?.text = element.nekogo
         return cell
     }
 }

--- a/NyanNyanEngineTests/NekosanConverterTest.swift
+++ b/NyanNyanEngineTests/NekosanConverterTest.swift
@@ -1,0 +1,20 @@
+//
+//  NekosanConverterTest.swift
+//  NyanNyanEngineTests
+//
+//  Created by Tetsuya Nishikawa on 2019/05/06.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import XCTest
+@testable import NyanNyanEngine
+
+class NekosanConverterTest: XCTestCase {
+    func testNekosan() {
+        let testStr = "どんな嫌なツイートでも、猫語だと可愛いですね。"
+        
+        let testNekogo = Nekosan().createNekogo(sourceStr: testStr)
+        let expectedNekogo = "にゃーおんにゃおにゃー"
+        XCTAssertEqual(testNekogo, expectedNekogo)
+    }
+}


### PR DESCRIPTION
ツイート本文から猫語の算出はMD5を用いて実施。計算値の頭から3桁と末尾の1桁で猫語本文と猫語接尾辞とした。

MD5の計算は、HMAC_SHA1認証にも使っている下記ライブラリを使用。
https://github.com/krzyzanowskim/CryptoSwift