### PR TITLE
ユーザー名が長すぎるとき、投稿時間が消えてしまう不具合を修正

### DIFF
--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -38,18 +38,18 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
-                                                    <rect key="frame" x="72" y="16" width="112" height="19.5"/>
+                                                    <rect key="frame" x="72" y="16" width="96" height="19.5"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="112" id="vxd-9S-r1N"/>
+                                                        <constraint firstAttribute="width" constant="96" id="vxd-9S-r1N"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
-                                                    <rect key="frame" x="192" y="16" width="100" height="19.5"/>
+                                                    <rect key="frame" x="176" y="16" width="128" height="19.5"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="cKu-2r-aIA"/>
+                                                        <constraint firstAttribute="width" constant="128" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
今回触った部分である`UILabel` を固定にしてしまうと、警告が出てしまうのだが実害はないので無視することとする。