### PR TITLE
発語時間が表示されるようにした

### DIFF
--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		679A5E65227B3B590043D0E1 /* PlistConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679A5E64227B3B590043D0E1 /* PlistConnector.swift */; };
 		679A5E67227B3E960043D0E1 /* ApiKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 679A5E66227B3E960043D0E1 /* ApiKeys.plist */; };
 		67D86EE0227FC5DB00965816 /* NyanNyan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D86EDF227FC5DB00965816 /* NyanNyan.swift */; };
+		67D86EE2227FDE9B00965816 /* TwitterDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D86EE1227FDE9B00965816 /* TwitterDateFormatter.swift */; };
+		67D86EE4227FE20E00965816 /* DateFormatterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D86EE3227FE20E00965816 /* DateFormatterTest.swift */; };
 		67F88C0A227C2484004DF44A /* UserDefaultsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */; };
 		A3EF89A62D1B991E9600FCFA /* Pods_NyanNyanEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9151EC8B3866FB493C75F6A9 /* Pods_NyanNyanEngine.framework */; };
 /* End PBXBuildFile section */
@@ -93,6 +95,8 @@
 		679A5E64227B3B590043D0E1 /* PlistConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistConnector.swift; sourceTree = "<group>"; };
 		679A5E66227B3E960043D0E1 /* ApiKeys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ApiKeys.plist; sourceTree = "<group>"; };
 		67D86EDF227FC5DB00965816 /* NyanNyan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NyanNyan.swift; sourceTree = "<group>"; };
+		67D86EE1227FDE9B00965816 /* TwitterDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterDateFormatter.swift; sourceTree = "<group>"; };
+		67D86EE3227FE20E00965816 /* DateFormatterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterTest.swift; sourceTree = "<group>"; };
 		67F88C09227C2484004DF44A /* UserDefaultsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsConnector.swift; sourceTree = "<group>"; };
 		6D8A98757771D333C6941F1B /* Pods-NyanNyanEngineTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngineTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngineTests/Pods-NyanNyanEngineTests.release.xcconfig"; sourceTree = "<group>"; };
 		6F7E9C80946FAE4B36BBC437 /* Pods-NyanNyanEngine.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NyanNyanEngine.release.xcconfig"; path = "Pods/Target Support Files/Pods-NyanNyanEngine/Pods-NyanNyanEngine.release.xcconfig"; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 				670E397A227E715F002318AE /* constant */,
 				6723B28122767C7F0004FB3D /* dataclass */,
 				670E397F227FB67C002318AE /* Nekosan.swift */,
+				67D86EE1227FDE9B00965816 /* TwitterDateFormatter.swift */,
 			);
 			path = entity;
 			sourceTree = "<group>";
@@ -243,6 +248,7 @@
 				6766617E227527FF004C886C /* Info.plist */,
 				6723B285227682F60004FB3D /* JsonDecodeTests.swift */,
 				670E397D227FB4F7002318AE /* NekosanConverterTest.swift */,
+				67D86EE3227FE20E00965816 /* DateFormatterTest.swift */,
 			);
 			path = NyanNyanEngineTests;
 			sourceTree = "<group>";
@@ -542,6 +548,7 @@
 				6767B0D022791033008913EA /* TweetsRepository.swift in Sources */,
 				6723B28C2276970A0004FB3D /* Status.swift in Sources */,
 				670E3980227FB67C002318AE /* Nekosan.swift in Sources */,
+				67D86EE2227FDE9B00965816 /* TwitterDateFormatter.swift in Sources */,
 				670E397C227E7179002318AE /* DefaultNekosan.swift in Sources */,
 				6734D7F32279803200A19044 /* TweetSummaryCell.swift in Sources */,
 				6734D7F5227982BE00A19044 /* TweetSummaryDataSource.swift in Sources */,
@@ -566,6 +573,7 @@
 			files = (
 				670E397E227FB4F7002318AE /* NekosanConverterTest.swift in Sources */,
 				6723B286227682F60004FB3D /* JsonDecodeTests.swift in Sources */,
+				67D86EE4227FE20E00965816 /* DateFormatterTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -38,25 +38,25 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="にしかわ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpO-br-q46" userLabel="User Name">
-                                                    <rect key="frame" x="72" y="16" width="96" height="19.5"/>
+                                                    <rect key="frame" x="72" y="16" width="65.5" height="19.5"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="96" id="vxd-9S-r1N"/>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="96" id="vxd-9S-r1N"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.16862745098039217" blue="0.21176470588235294" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@nishikawa_shi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A6H-dr-b3W" userLabel="User Id">
-                                                    <rect key="frame" x="176" y="16" width="128" height="19.5"/>
+                                                    <rect key="frame" x="145.5" y="16" width="96" height="19.5"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="128" id="cKu-2r-aIA"/>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="96" id="cKu-2r-aIA"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22 h" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEj-Gh-Mzy" userLabel="Published At">
-                                                    <rect key="frame" x="361" y="18.5" width="29" height="17"/>
+                                                    <rect key="frame" x="369" y="18.5" width="29" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.34509803921568627" green="0.43137254901960786" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -72,14 +72,13 @@
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="9R4-Ud-2lt"/>
                                                 <constraint firstItem="PEj-Gh-Mzy" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="AG4-gh-IQ4"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="top" secondItem="nsg-uh-dnN" secondAttribute="top" id="DIB-qf-Orr"/>
-                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-24" id="H74-yU-XnA"/>
+                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="trailing" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="-16" id="H74-yU-XnA"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="bottom" secondItem="hpO-br-q46" secondAttribute="bottom" id="MEK-tK-vc2"/>
                                                 <constraint firstItem="hpO-br-q46" firstAttribute="leading" secondItem="nsg-uh-dnN" secondAttribute="trailing" constant="8" id="PWp-Tf-vsk"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="leading" secondItem="3yw-Hu-2gQ" secondAttribute="leading" constant="16" id="aG9-LE-T29"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3yw-Hu-2gQ" secondAttribute="trailing" constant="20" symbolic="YES" id="f1f-Um-W1M"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="top" secondItem="hpO-br-q46" secondAttribute="bottom" constant="8" id="gxj-kH-q6j"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="height" secondItem="hpO-br-q46" secondAttribute="height" id="nXP-3q-MVe"/>
-                                                <constraint firstItem="PEj-Gh-Mzy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A6H-dr-b3W" secondAttribute="trailing" constant="8" id="rVr-lz-4dF"/>
                                                 <constraint firstItem="tUf-t7-w8I" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="leading" id="v4A-MV-OwQ"/>
                                                 <constraint firstItem="A6H-dr-b3W" firstAttribute="leading" secondItem="hpO-br-q46" secondAttribute="trailing" constant="8" id="xlN-zg-45l"/>
                                                 <constraint firstItem="nsg-uh-dnN" firstAttribute="top" secondItem="3yw-Hu-2gQ" secondAttribute="top" constant="16" id="xqe-Wj-ji3"/>

--- a/NyanNyanEngine/model/entity/TwitterDateFormatter.swift
+++ b/NyanNyanEngine/model/entity/TwitterDateFormatter.swift
@@ -1,0 +1,42 @@
+//
+//  DateFormatter.swift
+//  NyanNyanEngine
+//
+//  Created by Tetsuya Nishikawa on 2019/05/06.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import Foundation
+
+class TwitterDateFormatter {
+    func getNyanNyanTimeStamp(apiTimeStamp: String) -> String {
+        let twitterDateFormatter = DateFormatter()
+        twitterDateFormatter.dateFormat = "EEE MMM dd HH:mm:ss Z y"
+        twitterDateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        
+        guard let createdAtDate = twitterDateFormatter.date(from: apiTimeStamp) else { return "秘密" }
+        
+        let createdAtUnixTimeStanp = createdAtDate.timeIntervalSince1970
+        let currentUnixTimeStamp = Date().timeIntervalSince1970
+        
+        let passedSecFromCreatedAt = currentUnixTimeStamp - createdAtUnixTimeStanp
+        
+        if (passedSecFromCreatedAt < 60 * 60) {
+            let passedMins = String(Int(passedSecFromCreatedAt / 60))
+            let passedMinsSuffix = "分前"
+            return [passedMins, passedMinsSuffix].joined()
+        } else if (passedSecFromCreatedAt < 60 * 60 * 24) {
+            let passedHours = String(Int(passedSecFromCreatedAt / (60 * 60)))
+            let passedHoursSuffix = "時間前"
+            return [passedHours + passedHoursSuffix].joined()
+        } else if (passedSecFromCreatedAt < 60 * 60 * 24 * 7) {
+            let passedDays = String(Int(passedSecFromCreatedAt / (60 * 60 * 24)))
+            let passedDaysSuffix = "日前"
+            return [passedDays, passedDaysSuffix].joined()
+        } else {
+            let farPassedDateFormatter = DateFormatter()
+            farPassedDateFormatter.dateFormat = "y/MM/dd"
+            return farPassedDateFormatter.string(from: createdAtDate)
+        }
+    }
+}

--- a/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
+++ b/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
@@ -11,51 +11,61 @@ struct DefaultNekosan {
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "1分前",
                  nekogo: "にゃんにゃにゃおん\n(訳: ここは猫さんの世界)"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "2分前",
                  nekogo: "にゃあにゃおーんにゃ\n(訳: 言葉がみんな猫語になるよ)"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "3分前",
                  nekogo: "にゃんにゃーにゃーお\n(訳: ツイッターでログインして)"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "4分前",
                  nekogo: "にゃにゃんにゃ\n(訳: 一緒に楽しく遊ぼうよ)"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "28分前",
                  nekogo: "🐟"),
         
         NyanNyan(profileUrl: nil,
                  userName: "猫一＠起業家",
                  userId: "neko_is_the_top",
+                 nyanedAt: "3時間前",
                  nekogo: "にゃーんにゃーにゃん"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "にゃんこグリップ",
                  userId: "sutaddoresu_nekosan",
+                 nyanedAt: "23時間前",
                  nekogo: "にゃあにゃんにゃー"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ニャン・ニャーンス I世",
                  userId: "nyan_nyaaansu",
+                 nyanedAt: "2日前",
                  nekogo: "にゃおにゃにゃおーん"),
         
         NyanNyan(profileUrl: nil,
                  userName: "猫さんドロイド",
                  userId: "neko_droid",
+                 nyanedAt: "5日前",
                  nekogo: "にゃあにゃおにゃー"),
         
         NyanNyan(profileUrl: "https://pbs.twimg.com/profile_images/1003237257631821824/EN5tK3hB_normal.jpg",
                  userName: "ブーツキャット",
                  userId: "hosome_zubon",
+                 nyanedAt: "1992/01/01",
                  nekogo: "にゃーんにゃおにゃー"),
     ]
 }

--- a/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
+++ b/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
@@ -12,5 +12,6 @@ struct NyanNyan {
     let profileUrl: String?
     let userName: String
     let userId: String
+    let nyanedAt: String
     let nekogo: String
 }

--- a/NyanNyanEngine/model/entity/dataclass/api/Status.swift
+++ b/NyanNyanEngine/model/entity/dataclass/api/Status.swift
@@ -10,5 +10,6 @@ import Foundation
 
 struct Status: Codable {
     let text: String
+    let createdAt: String
     let user: User
 }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -88,6 +88,7 @@ class TweetsRepository: BaseTweetsRepository {
             NyanNyan(profileUrl: $0.user.profileImageUrlHttps,
                      userName: $0.user.name,
                      userId: ("@" + $0.user.screenName),
+                     nyanedAt: TwitterDateFormatter().getNyanNyanTimeStamp(apiTimeStamp: $0.createdAt),
                      nekogo: Nekosan().createNekogo(sourceStr: $0.text))
         } ?? []
     }

--- a/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
+++ b/NyanNyanEngine/ui/view/TweetSummaryDataSource.swift
@@ -34,6 +34,7 @@ class TweetSummaryDataSource: NSObject, UITableViewDataSource {
         
         cell.userName?.text = element.userName
         cell.userId?.text = element.userId
+        cell.publishedAt?.text = element.nyanedAt
         cell.tweetBody?.text = element.nekogo
         return cell
     }

--- a/NyanNyanEngineTests/DateFormatterTest.swift
+++ b/NyanNyanEngineTests/DateFormatterTest.swift
@@ -1,0 +1,19 @@
+//
+//  DateFormatterTest.swift
+//  NyanNyanEngineTests
+//
+//  Created by Tetsuya Nishikawa on 2019/05/06.
+//  Copyright © 2019 Tetsuya Nishikawa. All rights reserved.
+//
+
+import XCTest
+@testable import NyanNyanEngine
+
+class DateFormatterTest: XCTestCase {
+    func testGetNyanNyanTimeStamp() {
+        let testApiTimeStamp = "Fri Apr 03 10:12:54 +0000 2018"
+        let testNyanNyanTimeStamp = TwitterDateFormatter().getNyanNyanTimeStamp(apiTimeStamp: testApiTimeStamp)
+        let expectedNyanNyanTimeStamp = "2018/04/03"
+        XCTAssertEqual(testNyanNyanTimeStamp, expectedNyanNyanTimeStamp)
+    }
+}

--- a/NyanNyanEngineTests/JsonDecodeTests.swift
+++ b/NyanNyanEngineTests/JsonDecodeTests.swift
@@ -108,6 +108,7 @@ class JsonDecodeTests: XCTestCase {
         let testStatusObj = try! decoder!.decode([Status].self, from: testJson).first!
         
         XCTAssertEqual(testStatusObj.text, "28日は、ちょーいい日で、めっちゃ笑って、水飲んで寝た")
+        XCTAssertEqual(testStatusObj.createdAt, "Sun Apr 28 21:00:00 +0000 2019")
         XCTAssertEqual(testStatusObj.user.name, "ハイボールマン 3号")
         XCTAssertEqual(testStatusObj.user.screenName, "oauth_dancer")
         XCTAssertEqual(testStatusObj.user.profileImageUrlHttps, "https://si0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg")
@@ -204,6 +205,7 @@ class JsonDecodeTests: XCTestCase {
         XCTAssertEqual(testStatusObj.user.screenName, "oauth_dancer")
         XCTAssertEqual(testStatusObj.user.profileImageUrlHttps, "https://si0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg")
         XCTAssertEqual(testStatusObj.text, "28日は、ちょーいい日で、めっちゃ笑って、水飲んで寝た")
+        XCTAssertEqual(testStatusObj.createdAt, "Sun Apr 28 21:00:00 +0000 2019")
     }
     
     func testCanParseUser() {


### PR DESCRIPTION
表示の仕方は本家twitter webサイトの投稿日時と同じく、7日以内の投稿だったら今からどれだけ前かを表示し、7日より前の投稿だったら投稿日時を `yyyy/mm/dd` で表示する仕様とした。

時間の計算は厄介な点が多かったが、下記が大変参考になった。
https://qiita.com/rinov/items/bff12e9ea1251e895306
https://qiita.com/alpha22jp/items/676dca97ad54b86645e7
http://www.unicode.org/reports/tr35/tr35-25.html#Date_Field_Symbol_Table