### PR TITLE
猫語がツイートできるようにした

### DIFF
--- a/NyanNyanEngine/Base.lproj/Main.storyboard
+++ b/NyanNyanEngine/Base.lproj/Main.storyboard
@@ -225,9 +225,6 @@
                                         <integer key="value" value="4"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="touchPostNekogoAction:" destination="Ync-nX-9TU" eventType="touchUpInside" id="UyZ-iB-NAh"/>
-                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" red="0.99215686270000003" green="0.96470588239999999" blue="0.89019607840000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -265,6 +262,7 @@
                     <connections>
                         <outlet property="nekogoText" destination="0wL-SI-Y2R" id="jGK-F0-mqW"/>
                         <outlet property="originalText" destination="L1b-m5-lsS" id="xN9-of-KnR"/>
+                        <outlet property="tweetButton" destination="zbK-Xh-RcE" id="m6h-lA-hkV"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dCe-LR-bsa" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -14,6 +14,7 @@ protocol BaseTweetsRepository: AnyObject {
     var nyanNyanStatuses: Observable<[NyanNyan]?> { get }
     var buttonRefreshExecutedAt: AnyObserver<(() -> Void)>? { get }
     var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl?>? { get }
+    var postExecutedAs: AnyObserver<String?>? { get }
 }
 
 class TweetsRepository: BaseTweetsRepository {
@@ -26,6 +27,7 @@ class TweetsRepository: BaseTweetsRepository {
     let nyanNyanStatuses: Observable<[NyanNyan]?>
     var buttonRefreshExecutedAt: AnyObserver<(() -> Void)>? = nil
     var pullToRefreshExecutedAt: AnyObserver<UIRefreshControl?>? = nil
+    var postExecutedAs: AnyObserver<String?>? = nil
     
     private init(apiClient: BaseApiClient = ApiClient.shared,
                  userDefaultsConnector: BaseUserDefaultsConnector = UserDefaultsConnector.shared) {
@@ -72,6 +74,9 @@ class TweetsRepository: BaseTweetsRepository {
                 }
                 .bind(to: _statuses)
                 .disposed(by: self.disposeBag)
+        }
+        
+        self.postExecutedAs = AnyObserver<String?> { nekosanText in
         }
     }
     

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -77,6 +77,23 @@ class TweetsRepository: BaseTweetsRepository {
         }
         
         self.postExecutedAs = AnyObserver<String?> { nekosanText in
+            guard let apiKey = PlistConnector.shared.getString(withKey: "apiKey"),
+                let apiSecret = PlistConnector.shared.getString(withKey: "apiSecret"),
+                let accessToken = UserDefaultsConnector.shared.getString(withKey: "oauth_token"),
+                let accessTokenSecret = UserDefaultsConnector.shared.getString(withKey: "oauth_token_secret"),
+                let nekosanTextValue = nekosanText.element,
+                let nekosanTextBody = nekosanTextValue,
+                let urlRequest = ApiRequestFactory(apiKey: apiKey,
+                                                   apiSecret: apiSecret,
+                                                   oauthNonce: "0000",
+                                                   accessTokenSecret: accessTokenSecret,
+                                                   accessToken: accessToken).createPostTweetRequest(tweetBody: nekosanTextBody) else {
+                                                    return
+            }
+            self.apiClient.executeHttpRequest(urlRequest: urlRequest)
+                .subscribe { res in
+                    print("tsuushinn shimashita")
+                }.disposed(by: self.disposeBag)
         }
     }
     

--- a/NyanNyanEngine/ui/postNekogo/PostNekogoViewController.swift
+++ b/NyanNyanEngine/ui/postNekogo/PostNekogoViewController.swift
@@ -31,12 +31,9 @@ class PostNekogoViewController: UIViewController {
     
     @IBOutlet weak var originalText: UITextView!
     @IBOutlet weak var nekogoText: UILabel!
+    @IBOutlet weak var tweetButton: UIButton!
     
     @IBAction func touchCancelAction(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
-    }
-    
-    @IBAction func touchPostNekogoAction(_ sender: UIButton) {
         self.dismiss(animated: true, completion: nil)
     }
     
@@ -46,6 +43,13 @@ class PostNekogoViewController: UIViewController {
 
         originalText.rx.text
             .bind(to: input.originalTextChangedTo!)
+            .disposed(by: disposeBag)
+        
+        tweetButton.rx.tap
+            .map { [unowned self] in
+                self.dismiss(animated: true, completion: nil)
+            }
+            .subscribe()
             .disposed(by: disposeBag)
         
         output.nekogoText

--- a/NyanNyanEngine/ui/postNekogo/PostNekogoViewController.swift
+++ b/NyanNyanEngine/ui/postNekogo/PostNekogoViewController.swift
@@ -47,6 +47,7 @@ class PostNekogoViewController: UIViewController {
         
         tweetButton.rx.tap
             .map { [unowned self] in
+                self.input.postExecutedAs?.onNext(self.nekogoText.text)
                 self.dismiss(animated: true, completion: nil)
             }
             .subscribe()

--- a/NyanNyanEngine/ui/postNekogo/PostNekogoViewModel.swift
+++ b/NyanNyanEngine/ui/postNekogo/PostNekogoViewModel.swift
@@ -12,6 +12,7 @@ import RxRelay
 
 protocol PostNekogoViewModelInput: AnyObject {
     var originalTextChangedTo: AnyObserver<String?>? { get }
+    var postExecutedAs: AnyObserver<String?>? { get }
 }
 
 protocol PostNekogoViewModelOutput: AnyObject {
@@ -19,11 +20,16 @@ protocol PostNekogoViewModelOutput: AnyObject {
 }
 
 final class PostNekogoViewModel: PostNekogoViewModelInput, PostNekogoViewModelOutput {
+    private let tweetsRepository: BaseTweetsRepository
+    
     var originalTextChangedTo: AnyObserver<String?>? = nil
+    var postExecutedAs: AnyObserver<String?>? = nil
     
     var nekogoText: Observable<String?>
     
-    init() {
+    init(tweetsRepository: BaseTweetsRepository = TweetsRepository.shared) {
+        self.tweetsRepository = tweetsRepository
+        
         let _nekogoText = BehaviorRelay<String?>(value: nil)
         self.nekogoText = _nekogoText.asObservable()
         
@@ -31,6 +37,11 @@ final class PostNekogoViewModel: PostNekogoViewModelInput, PostNekogoViewModelOu
             guard let texiViewValue = $0.element,
                 let originalText = texiViewValue else { return }
             _nekogoText.accept(Nekosan().createNekogo(sourceStr: originalText))
+        }
+        
+        self.postExecutedAs = AnyObserver<String?> {
+            guard let labelValue = $0.element else { return }
+            tweetsRepository.postExecutedAs?.onNext(labelValue)
         }
     }
 }


### PR DESCRIPTION
signature作成に必要なurlに、クエリストリングが付与された状態のフルパスを渡してしまうのがダメだということになかなか気づけずハマった

下記記事が参考になった。
https://stackoverflow.com/questions/10406588/api-requires-post-arguments-in-a-query-string

下記も署名を作成する上で参考になった。
が、2019年5月現在、`statuses/update.json`は、`status`属性はリクエストボディではなくクエリストリングに付与するものと仕様が変わっているため、注意が必要
https://syncer.jp/Web/API/Twitter/REST_API/#section-5