### PR TITLE
機能追加したので、バージョン番号の2桁目をあげることにした

### DIFF
--- a/NyanNyanEngine/Info.plist
+++ b/NyanNyanEngine/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
`1.0.1.0` ではなくて、ストア上の番号も上がる `1.1.0.0` の方が適切そう