### PR TITLE
バージョン番号をインクリメント

### DIFF
--- a/NyanNyanEngine/Info.plist
+++ b/NyanNyanEngine/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
問題になっていたのはXcodeがベータ版であったことではなく、macのOSをカタリナにあげてしまっていたことだった模様

https://stackoverflow.com/questions/56518791/app-store-refuses-my-update-after-installing-xcode-11-beta-with-keeping-xcode-10

なので、再アップロードするためにインクリメント実施