### PR TITLE
スクロールが下に行くたびに、過去のツイートが追加されるようにした

### DIFF
--- a/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
+++ b/NyanNyanEngine/model/entity/constant/DefaultNekosan.swift
@@ -8,7 +8,8 @@
 
 struct DefaultNekosan {
     let nyanNyanStatuses: [NyanNyan] = [
-        NyanNyan(profileUrl: "https://nyannyanengine.firebaseapp.com/assets/nyannya_sensei.png",
+        NyanNyan(id: 28,
+                 profileUrl: "https://nyannyanengine.firebaseapp.com/assets/nyannya_sensei.png",
                  userName: R.string.stringValues.default_user_name(),
                  userId: R.string.stringValues.default_user_id(),
                  nyanedAt: R.string.stringValues.default_user_posted_at(),

--- a/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
+++ b/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
@@ -20,7 +20,7 @@ struct NyanNyan: Equatable {
     var isNekogo: Bool = true
 }
 extension NyanNyan: IdentifiableType {
-    var identity: String {
-        return [ningengo, userId].joined()
+    var identity: Int {
+        return id
     }
 }

--- a/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
+++ b/NyanNyanEngine/model/entity/dataclass/NyanNyan.swift
@@ -10,6 +10,7 @@ import Foundation
 import Differentiator
 
 struct NyanNyan: Equatable {
+    let id: Int
     let profileUrl: String?
     let userName: String
     let userId: String

--- a/NyanNyanEngine/model/entity/dataclass/api/Status.swift
+++ b/NyanNyanEngine/model/entity/dataclass/api/Status.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct Status: Codable {
+    let id: Int
     let text: String
     let createdAt: String
     let user: User

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -90,11 +90,12 @@ class TweetsRepository: BaseTweetsRepository {
         }
         
         self.infiniteScrollExecutedAt = AnyObserver<(() -> Void)> { stopActivityIndicator in
-            //TODO: 表示中ツイートのもっとも古いIDが動的に設定されるようにする
-            self.getHomeTimeLine(maxId: "1147106841010135040")
+            self.getHomeTimeLine(maxId: String(self.currentMinId))
                 .map { [unowned self] in
                     self.updateMin(statuses: $0)
-                    return $0
+                    var additive = $0
+                    additive?.removeFirst()
+                    return additive
                 }
                 .map { (_statuses.value ?? []) + ($0 ?? []) }
                 .bind(to: _statuses)

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -93,8 +93,10 @@ class TweetsRepository: BaseTweetsRepository {
             self.getHomeTimeLine(maxId: String(self.currentMinId))
                 .map { [unowned self] in
                     self.updateMin(statuses: $0)
-                    var additive = $0
-                    additive?.removeFirst()
+                    guard var additive = $0 else { return $0 }
+                    if(!additive.isEmpty) {
+                        additive.removeFirst()
+                    }
                     return additive
                 }
                 .map { (_statuses.value ?? []) + ($0 ?? []) }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -107,7 +107,7 @@ class TweetsRepository: BaseTweetsRepository {
                     //Observerの型をラムダ式ではなくStringにしたかったのでここでLoadingStatusRepositoryへの依存が生まれてしまっている。
                     //モジュール性が若干下がるので、構成を見直した方が良いかもしれない・・・
                     LoadingStatusRepository.shared.loadingStatusChangedTo.onNext(false)
-                    return $0 ?? Status(text: "にゃにゃーーーおん", createdAt: "99日前", user: User(name: "エラー猫さん", screenName: "neko_error", profileImageUrlHttps: nil))
+                    return $0 ?? Status(id: 2828, text: "にゃにゃーーーおん", createdAt: "99日前", user: User(name: "エラー猫さん", screenName: "neko_error", profileImageUrlHttps: nil))
                 }
                 .bind(to: _postedStatus)
                 .disposed(by: self.disposeBag)
@@ -168,7 +168,8 @@ class TweetsRepository: BaseTweetsRepository {
     
     private func toNyanNyan(rawTweets: [Status]?) -> [NyanNyan] {
         return rawTweets?.map {
-            NyanNyan(profileUrl: $0.user.profileImageUrlHttps,
+            NyanNyan(id: $0.id,
+                     profileUrl: $0.user.profileImageUrlHttps,
                      userName: $0.user.name,
                      userId: ("@" + $0.user.screenName),
                      nyanedAt: TwitterDateFormatter().getNyanNyanTimeStamp(apiTimeStamp: $0.createdAt),

--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
@@ -75,7 +75,8 @@ class HomeTimelineViewController: UIViewController {
             .map { NyanNyanSection(items: $0, idSuffix: "main") }
 
         let loadingObservable = output.isInfiniteLoading
-            .map { $0 ? [NyanNyan(profileUrl: nil,
+            .map { $0 ? [NyanNyan(id: 282828,
+                profileUrl: nil,
                 userName: "LoadingName",
                 userId: "LoadingId",
                 nyanedAt: "LoadingNyan",

--- a/NyanNyanEngineTests/JsonDecodeTests.swift
+++ b/NyanNyanEngineTests/JsonDecodeTests.swift
@@ -107,6 +107,7 @@ class JsonDecodeTests: XCTestCase {
         
         let testStatusObj = try! decoder!.decode([Status].self, from: testJson).first!
         
+        XCTAssertEqual(testStatusObj.id, 240558470661799936)
         XCTAssertEqual(testStatusObj.text, "28日は、ちょーいい日で、めっちゃ笑って、水飲んで寝た")
         XCTAssertEqual(testStatusObj.createdAt, "Sun Apr 28 21:00:00 +0000 2019")
         XCTAssertEqual(testStatusObj.user.name, "ハイボールマン 3号")
@@ -204,6 +205,7 @@ class JsonDecodeTests: XCTestCase {
         XCTAssertEqual(testStatusObj.user.name, "ハイボールマン 3号")
         XCTAssertEqual(testStatusObj.user.screenName, "oauth_dancer")
         XCTAssertEqual(testStatusObj.user.profileImageUrlHttps, "https://si0.twimg.com/profile_images/730275945/oauth-dancer_normal.jpg")
+        XCTAssertEqual(testStatusObj.id, 240558470661799936)
         XCTAssertEqual(testStatusObj.text, "28日は、ちょーいい日で、めっちゃ笑って、水飲んで寝た")
         XCTAssertEqual(testStatusObj.createdAt, "Sun Apr 28 21:00:00 +0000 2019")
     }


### PR DESCRIPTION
related #83

`max_id` を指定したリクエストをしても、 `max_id` のツイートは追加読み込みの先頭に入ってきてしまうので除去するのが必要だった。
除去には下記記事が参考になった

https://swift.tecc0.com/?p=218