### PR TITLE
かなり下まで引っ張らないと無限スクロールできない事象を修正した

### DIFF
--- a/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
+++ b/NyanNyanEngine/ui/homeTimeLine/HomeTimelineViewController.swift
@@ -63,7 +63,7 @@ class HomeTimelineViewController: UIViewController {
             .bind(to: input.cellTapExecutedOn!)
             .disposed(by: disposeBag)
         
-        let prefetchRatio = 0.95
+        let prefetchRatio = 0.85
         let prefetchOffset: CGFloat = tweetList.frame.size.height
         tweetList.rx.contentOffset
             .filter {


### PR DESCRIPTION
ナビゲーションバーをつけたせいで、結構マジでしたに引っ張らないと追加読み込みが起きなくなってしまっていた現象を回避