### PR TITLE
前からあったバグを修正

### DIFF
--- a/NyanNyanEngine/model/repository/AuthRepository.swift
+++ b/NyanNyanEngine/model/repository/AuthRepository.swift
@@ -357,6 +357,11 @@ class AuthRepository: BaseAuthRepository {
     }
     
     private func saveTokens(accessTokenApiResponseQuery: [URLQueryItem]) {
+        //原因は不明だが、アカウントによってはoauth_tokenやoauth_token_secretにSANITIZEDが設定されたレスポンスが返ってくる場合がある。無効なものなので、保存しない
+        if accessTokenApiResponseQuery.map({ $0.value }).contains("SANITIZED") {
+            return
+        }
+        
         accessTokenApiResponseQuery.forEach { [unowned self] item in
             print(item)
             guard let value = item.value else { return }

--- a/NyanNyanEngine/model/repository/TweetsRepository.swift
+++ b/NyanNyanEngine/model/repository/TweetsRepository.swift
@@ -185,7 +185,7 @@ class TweetsRepository: BaseTweetsRepository {
     private func updateMin(statuses: [NyanNyan]?) {
         guard let statuses = statuses,
             let minId = statuses.map({$0.id}).min() else { return }
-        if(minId < self.currentMinId) {
+        if (minId < self.currentMinId) || (self.currentMinId == DefaultNekosan().nyanNyanStatuses[0].id) {
             self.currentMinId = minId
         }
     }


### PR DESCRIPTION
ログイン直後、無限スクロールが動作しなかった。
これは、追加読み込み用の `max_id` に、デフォルト値の、とても小さな値が設定されていたのが原因だった。