### PR TITLE
androidのアプリリンク用の値を設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,8 @@ NyanNyanEngine/GoogleService-Info-Release.plist
 public/apple-app-site-association
 public/.well-known/apple-app-site-association
 
+# App Links(for android dev)
+public/.well-known/assetlinks.json
+
 # R.swift
 *.generated.swift

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent : *
+Allow : /.well-known/assetlinks.json


### PR DESCRIPTION
## 背景

Firebaseのプロジェクト数をケチるために、iOSと向き先を同じにしたので
Androidの設定値をこちらに持たせることとなっている