### PR TITLE
Fastlane周りの扱いを更新

### DIFF
--- a/NyanNyanEngine.xcodeproj/project.pbxproj
+++ b/NyanNyanEngine.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$SRCROOT/R.generated.swift",
+				$SRCROOT/R.generated.swift,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1076,7 +1076,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
 				BUNDLE_ID_SUFFIX = .debug;
 				CODE_SIGN_ENTITLEMENTS = NyanNyanEngine/NyanNyanEngine.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = K85M397W48;
 				INFOPLIST_FILE = NyanNyanEngine/Info.plist;
@@ -1087,6 +1087,7 @@
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ntetz.ios.NyanNyanEngine${BUNDLE_ID_SUFFIX}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.ntetz.ios.NyanNyanEngine.debug";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1099,7 +1100,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
 				BUNDLE_ID_SUFFIX = "";
 				CODE_SIGN_ENTITLEMENTS = NyanNyanEngine/NyanNyanEngine.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = K85M397W48;
 				INFOPLIST_FILE = NyanNyanEngine/Info.plist;
@@ -1110,6 +1112,7 @@
 				MARKETING_VERSION = 1.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ntetz.ios.NyanNyanEngine${BUNDLE_ID_SUFFIX}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.ntetz.ios.NyanNyanEngine";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,7 @@ platform :ios do
   lane :load_certs do
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
-        APP_IDENTIFIER_PRODUCTION
+        APP_IDENTIFIER_DEVELOP
       ],
       type: "development",
       readonly: true
@@ -32,7 +31,6 @@ platform :ios do
 
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
         APP_IDENTIFIER_PRODUCTION
       ],
       type: "adhoc",
@@ -62,8 +60,7 @@ platform :ios do
 
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
-        APP_IDENTIFIER_PRODUCTION
+        APP_IDENTIFIER_DEVELOP
       ],
       type: "development",
       force_for_new_devices: true
@@ -71,7 +68,6 @@ platform :ios do
 
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
         APP_IDENTIFIER_PRODUCTION
       ],
       type: "adhoc",
@@ -83,8 +79,7 @@ platform :ios do
   lane :produce_certs do
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
-        APP_IDENTIFIER_PRODUCTION
+        APP_IDENTIFIER_DEVELOP
       ],
       type: "development",
       readonly: false
@@ -92,7 +87,6 @@ platform :ios do
 
     match(
       app_identifier: [
-        APP_IDENTIFIER_DEVELOP,
         APP_IDENTIFIER_PRODUCTION
       ],
       type: "adhoc",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,32 +102,4 @@ platform :ios do
     )
   end
 
-  desc "プッシュ通知証明書生成lane"
-  lane :produce_push_certs do |options|
-    case options[:env]
-    when "develop"
-      produce_sandbox_and_production_push_certs_lane(
-        app_identifier: APP_IDENTIFIER_DEVELOP
-      )
-    when "production"
-      produce_sandbox_and_production_push_certs_lane(
-        app_identifier: APP_IDENTIFIER_PRODUCTION
-      )
-    else
-      raise("引数envを付与して実行してください。: `fastlane produce_push_certs env:(develop|production)`")
-    end
-  end
-
-  private_lane :produce_sandbox_and_production_push_certs_lane do |options|
-    if not options[:app_identifier]
-      raise("引数 app_identifier が不足しています")
-    end
-    pem(
-      app_identifier: options[:app_identifier],
-      development: true
-    )
-    pem(
-      app_identifier: options[:app_identifier]
-    )
-  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,11 +31,6 @@ provisioning profileへの端末追加lane
 fastlane ios produce_certs
 ```
 provisioning profile生成lane
-### ios produce_push_certs
-```
-fastlane ios produce_push_certs
-```
-プッシュ通知証明書生成lane
 
 ----
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS
@@ -39,6 +39,6 @@ fastlane ios produce_push_certs
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
## 概要

不要なプロビ作成と、証明書作成のlaneを削除。
また、作成したプロビがうまく参照されていなかったので修正。